### PR TITLE
feat(learning-guide): collapsible + resizable sidebar; Next marks read (1.1.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -75,7 +75,7 @@
     {
       "name": "learning-guide",
       "description": "Generate a self-contained, offline-first, interactive HTML learning guide for any artifact — codebase, planning session, refactor plan, or generic input — via an analyze → render flow with a JSON tour-spec contract",
-      "version": "1.0.11",
+      "version": "1.1.0",
       "author": {
         "name": "Dmitry Yuhanov"
       },

--- a/plugins/learning-guide/.claude-plugin/plugin.json
+++ b/plugins/learning-guide/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "learning-guide",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "description": "Generate a self-contained, offline-first, interactive HTML learning guide for any artifact — codebase, planning session, refactor plan, or generic input — via an analyze → render flow with a JSON tour-spec contract"
 }

--- a/plugins/learning-guide/CHANGELOG.md
+++ b/plugins/learning-guide/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the **learning-guide** plugin will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.1.0] - 2026-07-02
+
+### Added
+- The left sidebar can be collapsed (and reopened with a floating button) and resized by dragging its right edge or with the keyboard; the width and collapsed state persist per guide.
+
+### Changed
+- The "Next" button now also marks the current section as read — advancing counts as having read it.
+
 ## [1.0.11] - 2026-06-30
 
 ### Fixed

--- a/plugins/learning-guide/assets/i18n/en.json
+++ b/plugins/learning-guide/assets/i18n/en.json
@@ -16,5 +16,8 @@
   "finalQuiz": "Self-check",
   "glossary": "Glossary",
   "correct": "Correct",
-  "incorrect": "Incorrect"
+  "incorrect": "Incorrect",
+  "collapseSidebar": "Collapse sidebar",
+  "expandSidebar": "Show sidebar",
+  "resizeSidebar": "Resize sidebar"
 }

--- a/plugins/learning-guide/assets/i18n/ru.json
+++ b/plugins/learning-guide/assets/i18n/ru.json
@@ -16,5 +16,8 @@
   "finalQuiz": "Проверка знаний",
   "glossary": "Глоссарий",
   "correct": "Верно",
-  "incorrect": "Неверно"
+  "incorrect": "Неверно",
+  "collapseSidebar": "Свернуть панель",
+  "expandSidebar": "Показать панель",
+  "resizeSidebar": "Изменить ширину панели"
 }

--- a/plugins/learning-guide/assets/runtime.js
+++ b/plugins/learning-guide/assets/runtime.js
@@ -7,7 +7,8 @@
 
   var STORAGE_KEYS = {
     progress: 'lg.' + tourId + '.progress',
-    active: 'lg.' + tourId + '.active'
+    active: 'lg.' + tourId + '.active',
+    sidebar: 'lg.' + tourId + '.sidebar'
   };
 
   function t(key, fallback) {
@@ -103,7 +104,18 @@
     document.querySelectorAll('.pager [data-target]').forEach(function (el) {
       el.addEventListener('click', function (ev) {
         var target = el.getAttribute('data-target');
-        if (target) { ev.preventDefault(); activate(target); }
+        if (!target) return;
+        ev.preventDefault();
+        // "Next" also marks the current section as read — advancing implies you read it.
+        if (el.classList && el.classList.contains('next')) {
+          var sec = el.closest ? el.closest('.section') : null;
+          if (sec && sec.id) {
+            var p = loadProgress();
+            if (!p[sec.id]) { p[sec.id] = true; saveProgress(p); }
+          }
+        }
+        activate(target);
+        updateProgressDisplay();
       });
     });
   }
@@ -341,11 +353,91 @@
     return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
   }
 
+  // Collapsible + resizable left sidebar. Controls are injected here (so a user template
+  // override gets the feature too), positioned via the --lg-sidebar-w CSS variable, and the
+  // width/collapsed state persists in localStorage.
+  function bindSidebar() {
+    var layout = document.querySelector('.layout');
+    var aside = layout && layout.querySelector('aside');
+    if (!layout || !aside) return;
+    var root = document.documentElement;
+    var MINW = 180, MAXW = 640;
+
+    function ensure(id, make) {
+      var el = document.getElementById(id);
+      if (!el) { el = make(); el.id = id; document.body.appendChild(el); }
+      return el;
+    }
+    var collapseBtn = ensure('lg-sidebar-collapse', function () {
+      var b = document.createElement('button'); b.type = 'button'; b.className = 'lg-collapse-btn'; return b;
+    });
+    collapseBtn.textContent = String.fromCharCode(0x2039); // left-pointing angle "‹"
+    collapseBtn.setAttribute('aria-label', t('collapseSidebar', 'Collapse sidebar'));
+    var showBtn = ensure('lg-sidebar-show', function () {
+      var b = document.createElement('button'); b.type = 'button'; b.className = 'lg-sidebar-show'; return b;
+    });
+    showBtn.textContent = String.fromCharCode(0x2630); // trigram/menu "☰"
+    showBtn.setAttribute('aria-label', t('expandSidebar', 'Show sidebar'));
+    var handle = ensure('lg-sidebar-resize', function () {
+      var d = document.createElement('div'); d.className = 'lg-resize';
+      d.setAttribute('role', 'separator'); d.setAttribute('aria-orientation', 'vertical'); d.setAttribute('tabindex', '0');
+      return d;
+    });
+    handle.setAttribute('aria-label', t('resizeSidebar', 'Resize sidebar'));
+    handle.setAttribute('aria-valuemin', String(MINW));
+    handle.setAttribute('aria-valuemax', String(MAXW));
+
+    var state = { w: 300, collapsed: false };
+    try { var s = JSON.parse(localStorage.getItem(STORAGE_KEYS.sidebar) || 'null'); if (s) state = { w: s.w || 300, collapsed: !!s.collapsed }; } catch (e) {}
+    function save() { try { localStorage.setItem(STORAGE_KEYS.sidebar, JSON.stringify(state)); } catch (e) {} }
+    function clampW(w) { return Math.max(MINW, Math.min(MAXW, w)); }
+    function applyWidth() { root.style.setProperty('--lg-sidebar-w', state.w + 'px'); handle.setAttribute('aria-valuenow', String(state.w)); }
+    function applyCollapsed() {
+      document.body.classList.toggle('lg-collapsed', state.collapsed);
+      collapseBtn.setAttribute('aria-expanded', state.collapsed ? 'false' : 'true');
+      aside.setAttribute('aria-hidden', state.collapsed ? 'true' : 'false');
+    }
+    state.w = clampW(state.w);
+    applyWidth(); applyCollapsed();
+
+    function setCollapsed(v, focusEl) {
+      state.collapsed = v; applyCollapsed(); save();
+      if (focusEl && focusEl.focus) { try { focusEl.focus(); } catch (e) {} }
+    }
+    collapseBtn.addEventListener('click', function () { setCollapsed(true, showBtn); });
+    showBtn.addEventListener('click', function () { setCollapsed(false, collapseBtn); });
+
+    var dragging = false, startX = 0, startW = 0;
+    handle.addEventListener('pointerdown', function (ev) {
+      if (state.collapsed) return;
+      dragging = true; startX = ev.clientX; startW = state.w;
+      document.body.classList.add('lg-resizing');
+      try { handle.setPointerCapture(ev.pointerId); } catch (e) {}
+      ev.preventDefault();
+    });
+    handle.addEventListener('pointermove', function (ev) {
+      if (!dragging) return;
+      state.w = clampW(startW + (ev.clientX - startX));
+      applyWidth();
+    });
+    function endDrag() { if (dragging) { dragging = false; document.body.classList.remove('lg-resizing'); save(); } }
+    handle.addEventListener('pointerup', endDrag);
+    handle.addEventListener('pointercancel', endDrag);
+    handle.addEventListener('lostpointercapture', endDrag);
+    handle.addEventListener('keydown', function (ev) {
+      if (ev.key === 'ArrowLeft' || ev.key === 'ArrowRight') {
+        state.w = clampW(state.w + (ev.key === 'ArrowLeft' ? -16 : 16));
+        applyWidth(); save(); ev.preventDefault();
+      }
+    });
+  }
+
   function init() {
     bindNav();
     bindFilepathButtons();
     bindQuizzes();
     bindXrefs();
+    bindSidebar();
     var saved = null;
     try { saved = localStorage.getItem(STORAGE_KEYS.active); } catch (e) {}
     activate(saved && document.getElementById(saved) ? saved : (sections[0] || 'intro'));

--- a/plugins/learning-guide/assets/styles.css
+++ b/plugins/learning-guide/assets/styles.css
@@ -1,10 +1,10 @@
 *,*::before,*::after{box-sizing:border-box}
 html,body{margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;color:#1f2328;background:#fff;line-height:1.55;font-size:15px}
-.layout{display:grid;grid-template-columns:300px 1fr;min-height:100vh}
+.layout{display:grid;grid-template-columns:var(--lg-sidebar-w,300px) 1fr;min-height:100vh}
 aside{background:#0d1117;color:#c9d1d9;padding:1.25rem 1rem;position:sticky;top:0;height:100vh;overflow-y:auto;border-right:1px solid #30363d}
 main{padding:2rem 3rem;max-width:980px;width:100%;margin:0 auto}
 @media(max-width:900px){.layout{grid-template-columns:1fr}aside{position:static;height:auto}main{padding:1.5rem}}
-aside h1{font-size:1.1rem;color:#fff;margin:0 0 .25rem;padding:0}
+aside h1{font-size:1.1rem;color:#fff;margin:0 0 .25rem;padding:0 1.8rem 0 0}
 aside .subtitle{font-size:.78rem;color:#8b949e;margin-bottom:1.25rem;letter-spacing:.02em}
 aside nav ul{list-style:none;padding:0;margin:0}
 aside nav li{margin:.05rem 0}
@@ -74,3 +74,16 @@ main li{margin:.25rem 0}
 .anchor-flash{background:#fff8c5;transition:background 1.5s}
 @media(max-width:760px){.md-viewer{width:100vw}}
 .mermaid{background:#fbfbfb;border:1px solid #d0d7de;border-radius:8px;padding:1rem;margin:1rem 0;overflow-x:auto;text-align:center;white-space:pre-wrap}
+/* Collapsible + resizable left sidebar */
+.lg-collapse-btn{position:fixed;top:.6rem;left:calc(var(--lg-sidebar-w,300px) - 2.1rem);z-index:60;width:26px;height:26px;display:inline-flex;align-items:center;justify-content:center;background:#161b22;color:#c9d1d9;border:1px solid #30363d;border-radius:6px;cursor:pointer;font-size:1.15rem;line-height:1;padding:0;font-family:inherit}
+.lg-collapse-btn:hover,.lg-collapse-btn:focus-visible{background:#21262d;color:#fff;outline:2px solid #1f6feb;outline-offset:1px}
+.lg-resize{position:fixed;top:0;left:calc(var(--lg-sidebar-w,300px) - 3px);width:7px;height:100vh;cursor:col-resize;background:transparent;z-index:55}
+.lg-resize:hover,.lg-resize:focus-visible{background:#1f6feb66;outline:none}
+body.lg-resizing{user-select:none;cursor:col-resize}
+.lg-sidebar-show{position:fixed;top:.6rem;left:.6rem;z-index:1500;width:40px;height:40px;display:none;align-items:center;justify-content:center;background:#0d1117;color:#fff;border:1px solid #30363d;border-radius:8px;cursor:pointer;font-size:1.2rem;box-shadow:0 3px 10px rgba(0,0,0,.25);font-family:inherit}
+.lg-sidebar-show:hover,.lg-sidebar-show:focus-visible{background:#161b22;color:#fff;outline:2px solid #1f6feb;outline-offset:1px}
+body.lg-collapsed .layout{grid-template-columns:1fr}
+body.lg-collapsed aside{display:none}
+body.lg-collapsed .lg-resize,body.lg-collapsed .lg-collapse-btn{display:none}
+body.lg-collapsed .lg-sidebar-show{display:inline-flex}
+@media(max-width:900px){.lg-resize{display:none}.lg-collapse-btn{left:auto;right:.6rem}}

--- a/plugins/learning-guide/scripts/browser-verify.cjs
+++ b/plugins/learning-guide/scripts/browser-verify.cjs
@@ -144,6 +144,41 @@ function renderFixture() {
   const progReload = ((await page.locator('#progress-text').textContent()) || '').trim();
   check('progress persists across reload (localStorage)', /^[1-9]/.test(progReload), 'progress="' + progReload + '"');
 
+  // sidebar collapse / expand
+  await page.locator('#lg-sidebar-collapse').click();
+  await page.waitForTimeout(150);
+  check('sidebar collapses (aside hidden, show button visible)',
+    (await page.evaluate(() => document.body.classList.contains('lg-collapsed')))
+    && await page.locator('#lg-sidebar-show').isVisible());
+  const mainW = (await page.locator('#content').boundingBox()).width;
+  check('collapsed: main content stays wide (does not squeeze to min-content)', mainW > 600, 'main=' + Math.round(mainW));
+  await page.locator('#lg-sidebar-show').click();
+  check('sidebar expands again',
+    await page.evaluate(() => !document.body.classList.contains('lg-collapsed')));
+
+  // sidebar resize (keyboard on the separator) + persistence
+  const readW = () => page.evaluate(() => parseInt(getComputedStyle(document.documentElement).getPropertyValue('--lg-sidebar-w')) || 300);
+  const w0 = await readW();
+  await page.locator('#lg-sidebar-resize').focus();
+  for (let k = 0; k < 5; k++) await page.keyboard.press('ArrowRight');
+  const w1 = await readW();
+  check('sidebar resize widens the panel', w1 > w0, 'w0=' + w0 + ' w1=' + w1);
+  await page.reload({ waitUntil: 'load' });
+  await page.waitForTimeout(200);
+  const w2 = await readW();
+  check('sidebar width persists across reload', w2 === w1, 'w1=' + w1 + ' w2=' + w2);
+
+  // "Next" also marks the current section as read
+  await page.evaluate(() => { try { localStorage.clear(); } catch (e) {} });
+  await page.reload({ waitUntil: 'load' });
+  await page.waitForTimeout(200);
+  const preNext = parseInt(((await page.locator('#progress-text').textContent()) || '0').trim()) || 0;
+  await page.locator('#intro button.next').click();
+  await page.waitForTimeout(100);
+  check('Next activates the target section', await page.locator('#architecture.active').count() === 1);
+  const postNext = parseInt(((await page.locator('#progress-text').textContent()) || '0').trim()) || 0;
+  check('Next also marks the current section read', preNext === 0 && postNext >= 1, 'before=' + preNext + ' after=' + postNext);
+
   check('no uncaught JS errors during the session', errors.length === 0, errors.join(' | '));
 
   await browser.close();


### PR DESCRIPTION
## What

Two enhancements to the generated learning guide, both from the request:

- The left sidebar is now collapsible and resizable. Drag its right edge (or use the keyboard on the separator) to resize it, or click the collapse button to hide it entirely; a floating button reopens it. The width and collapsed state are remembered per guide.
- "Next" now also marks the section as read. Clicking Next counts as having read the current section, so you don't have to click both buttons.

## How

The controls (collapse button, resize handle, reopen button) are injected by the runtime rather than baked into the template, so a user template override picks them up too. The layout width is driven by a `--lg-sidebar-w` CSS variable, and state persists in localStorage.

## Tests

68 unit tests, verify.cjs, and 28 Playwright browser checks (6 new: collapse/expand, keyboard resize with persistence, collapsed layout width, and Next-marks-read). Verified visually with screenshots of both states. The browser test also caught a layout bug where collapsing squeezed the main content down to one word per line; that is fixed.

## Version

1.1.0 (minor version bump for a new feature). Marketplace, README, and changelog updated.

https://claude.ai/code/session_01EKs6N1xoWFb3g2441uXfuT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a collapsible and resizable left sidebar with saved width and collapsed state.
  * Added keyboard-friendly sidebar resizing and a show-sidebar control when collapsed.

* **Bug Fixes**
  * The **Next** action now marks the current section as read before moving forward.
  * Sidebar state and progress now persist across reloads more reliably.

* **Chores**
  * Bumped the learning guide plugin version to **1.1.0**.
  * Updated release notes and localized sidebar labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->