### PR TITLE
feat(issue-to-pr): worktree isolation + approval-gated merge & cleanup

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -129,8 +129,8 @@
     },
     {
       "name": "issue-to-pr",
-      "description": "Drive a GitHub issue — bare or tracked on a Project board — from triage to a merge-ready PR through a gated pipeline (design cross-review, tests green, code-review loop). Auto-links the issue to close on merge and advances the board card's status as work progresses",
-      "version": "1.0.0",
+      "description": "Drive a GitHub issue — bare or tracked on a Project board — from triage to a merge-ready PR through a worktree-isolated, gated pipeline (design cross-review, tests green, code-review loop). After you approve the PR in-session it squash-merges and cleans up the branch, worktree, and temp artifacts. Auto-links the issue to close on merge and advances the board card's status as work progresses",
+      "version": "1.1.0",
       "author": {
         "name": "Dmitry Yuhanov"
       },

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can also install individual plugins directly, for example:
 | [codex-collaboration](#codex-collaboration) | Cross-model Claude + Codex collaboration — sequential drive/validate loops and parallel dual review |
 | [implementation-prd](#implementation-prd) | Turn feature requests into build-ready spec bundles with PRDs, contracts, schemas, and test plans |
 | [agent-teams](#agent-teams) | Orchestrate multiple Claude Code instances working in parallel with shared tasks and messaging |
-| [issue-to-pr](#issue-to-pr) | Drive a GitHub issue or Project board card from triage to a merge-ready PR through a gated pipeline |
+| [issue-to-pr](#issue-to-pr) | Drive a GitHub issue or Project board card through a worktree-isolated, gated pipeline to an approved, merged PR |
 | [tg-alerts](#tg-alerts) | Add Telegram error/alert notifications to any project — guided setup with reference implementations |
 | [tg-voice](#tg-voice) | Auto-transcribe Telegram voice messages using local Whisper via PostToolUse hook |
 
@@ -101,8 +101,10 @@ Implementation-ready spec bundle authoring with:
 Drive a single GitHub issue from triage to a merge-ready pull request through a gated pipeline:
 
 - One flow for a **bare issue** or a **card on a GitHub Projects (v2) board** — Step 0 resolves the input and decides whether board-status sync applies.
+- Each run works in its own `../<repo>-worktrees/issue-<N>` git worktree, so concurrent local agents on different issues never clash.
 - Hard gates that block forward progress: design hardening (cross-review or a multi-agent fallback), tests green (typecheck + tests, plus visual checks for UI), and a code-review loop that runs until clean or five passes.
-- The PR auto-links the issue (`Closes #N`) to close on merge; board cards advance to *in-progress* at branch cut and *in-review* at PR open, with `Done` left to merge-time automation.
+- Opens the PR and stops; once you approve it in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp artifacts (keeping anything important).
+- The PR auto-links the issue (`Closes #N`) to close on merge; board cards advance to *in-progress* at branch cut and *in-review* at PR open, with `Done` left to GitHub's merge-time automation.
 - Graceful by default — missing the `project` token scope degrades to link-only, and a failed status write never blocks the PR.
 - Optional `.claude/issue-to-pr.local.md` for board URL, base branch, and test commands (auto-detected when unset); companion skills (`superpowers:*`, `/deep-research`, `/cross-review`, `humanizer`, `/code-review`) used if installed, with inline fallbacks otherwise.
 

--- a/plugins/issue-to-pr/.claude-plugin/plugin.json
+++ b/plugins/issue-to-pr/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "issue-to-pr",
-  "version": "1.0.0",
-  "description": "Drive a GitHub issue — bare or tracked on a Project board — from triage to a merge-ready PR through a gated pipeline (design cross-review, tests green, code-review loop). Auto-links the issue to close on merge and advances the board card's status as work progresses",
+  "version": "1.1.0",
+  "description": "Drive a GitHub issue — bare or tracked on a Project board — from triage to a merge-ready PR through a worktree-isolated, gated pipeline (design cross-review, tests green, code-review loop). After you approve the PR in-session it squash-merges and cleans up the branch, worktree, and temp artifacts. Auto-links the issue to close on merge and advances the board card's status as work progresses",
   "author": {
     "name": "Dmitry Yuhanov"
   }

--- a/plugins/issue-to-pr/CHANGELOG.md
+++ b/plugins/issue-to-pr/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the **issue-to-pr** plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.1.0] - 2026-07-03
+
+### Added
+- Worktree isolation — each run works in its own `../<repo>-worktrees/issue-<N>` git worktree, so concurrent local agents on different issues never clash
+- Approval-gated merge — after you approve the PR in-session, the skill squash-merges and tears down the branch, worktree, and temp artifacts
+
 ## [1.0.0] - 2026-06-26
 
 ### Added

--- a/plugins/issue-to-pr/README.md
+++ b/plugins/issue-to-pr/README.md
@@ -19,14 +19,20 @@ work progresses.
 Invoked by the model or by you (`/issue-to-pr [issue-number | next]`) — a pipeline with hard
 gates that block forward progress:
 
+- **Isolated per task.** Each run cuts its branch inside a dedicated
+  `../<repo>-worktrees/issue-<N>` git worktree, so several local agents can drive different
+  issues in the same clone without clashing.
 - **Triage → design → implement → review → PR**, scaled to complexity (simple edits skip
   straight to TDD; complex work goes through brainstorming and a design cross-review gate).
 - **Gates:** design hardening (cross-review or a multi-agent fallback), tests green
   (typecheck + tests, plus visual checks for UI), and a code-review loop that runs until
   clean or five passes.
+- **Approval-gated merge + cleanup.** The PR opens and the skill stops. Once you approve it in
+  the session, the skill squash-merges, deletes the branch, tears down the worktree, and
+  removes the run's temp artifacts (keeping anything important or that you asked to keep).
 - **Issue ↔ board, one pipeline.** Step 0 resolves the input to an issue and decides whether
   board-status sync applies. Board cards advance to *in-progress* at branch cut and
-  *in-review* at PR open; `Done` is left to merge-time automation.
+  *in-review* at PR open; `Done` is left to GitHub's merge-time automation.
 - **Graceful by default.** Missing the `project` token scope degrades to link-only with a
   one-line fix hint; a failed status write never blocks the PR.
 

--- a/plugins/issue-to-pr/skills/issue-to-pr/SKILL.md
+++ b/plugins/issue-to-pr/skills/issue-to-pr/SKILL.md
@@ -4,8 +4,10 @@ description: >-
   Drive a GitHub issue — bare or tracked on a Project board — from triage to a
   merge-ready PR through a gated pipeline (design cross-review, tests green,
   code-review loop). Auto-links the issue to close on merge and advances the
-  board card's status as work progresses. Triggers: "take task N",
-  "work on issue #N", "do the next task", "start issue 7".
+  board card's status as work progresses, then merges and cleans up once you
+  approve the PR in-session. Triggers: "take task N", "work on issue #N",
+  "do the next task", "start issue 7", and — for the merge gate on a follow-up
+  turn — "merge it", "approve the PR", "ship it", "lgtm merge".
 user-invocable: true
 argument-hint: "[issue-number | next]"
 ---
@@ -18,12 +20,16 @@ pull request. The shape is the same every time so nothing gets skipped. The **ga
 todo per step.
 
 The input can be a **bare issue** or a **card on a GitHub Projects (v2) board** — the
-pipeline is identical. The PR always links the issue so it auto-closes on merge; when the
-issue is tracked on a board, the card's status is advanced as work progresses (Step 0
-decides which mode applies).
+pipeline is identical. The PR always links the issue (`Closes #N`) so it auto-closes when the
+PR merges into the default branch; when the issue is tracked on a board, the card's status is
+advanced as work progresses (Step 0 decides which mode applies).
 
-This skill authorizes branching, committing, and opening a PR. It does **not** merge,
-deploy, or push to a protected base branch — those are separate, explicit actions.
+This skill authorizes branching, committing, and opening a PR — all inside an isolated
+worktree so concurrent local runs never clash. It **merges only after you approve the PR in
+this session** (squash), then cleans up the branch, worktree, and temp artifacts. The squash
+writes to the base branch, so that merge is the one irreversible step — it happens on nothing
+less than an explicit, unambiguous go-ahead (Step 11), and even then never force-pushes or
+bypasses branch protection.
 
 ## Configuration (optional)
 
@@ -32,6 +38,11 @@ URL, base branch, and the typecheck/test/visual commands. Everything is optional
 file the skill auto-detects commands and runs by issue argument. Schema and auto-detect
 rules: `${CLAUDE_PLUGIN_ROOT}/skills/issue-to-pr/references/configuration.md`. This guide
 refers to the resolved commands as `<typecheck_cmd>`, `<test_cmd>`, `<visual_cmd>`.
+
+**Resolve config in the main checkout, up front.** This file is gitignored, so it does not
+exist inside the worktree — read it (and the resolved commands + base) in `<original-root>`
+before entering the worktree, and carry the resolved values; never re-read config from inside
+the worktree, or the pinned commands are silently lost to auto-detect.
 
 ## Companion skills (optional, graceful)
 
@@ -45,11 +56,18 @@ otherwise the inline equivalent.
 
 ## Hard rules (never violate)
 
-- **New task = new branch.** Determine the integration base FIRST (from config
-  `base_branch`; `auto` = `dev` if it exists, else `main`), then cut the branch from THAT
-  same ref: `feat/<slug>` or `fix/<slug>`. The branch you start from and the PR target must
-  be the same base, or commits living only on `dev` go missing and surface as conflicts at
-  merge.
+- **New task = new branch, in its own worktree.** Determine the integration base FIRST (from
+  config `base_branch`; `auto` = `dev` if a `dev` branch exists locally or on the remote, else
+  `main`), then cut the branch from THAT same ref: `feat/issue-<N>-<slug>` or
+  `fix/issue-<N>-<slug>` (the issue number is baked in so the branch can't collide across
+  issues), inside a dedicated `../<repo>-worktrees/issue-<N>` worktree (see
+  `${CLAUDE_PLUGIN_ROOT}/skills/issue-to-pr/references/worktree-and-merge.md`). All work
+  happens there; never run two tasks in the same working tree. The branch you start from and
+  the PR target must be the same base, or commits living only on `dev` go missing and surface
+  as conflicts at merge.
+- **Merge is gated on explicit in-session approval.** Open the PR and stop. Only merge
+  (squash) after the user approves *this* PR in the session — never on the same turn the PR
+  opens. After a successful merge, clean up (Step 12).
 - Stage with **explicit paths** (`git add path1 path2`). Never `git add -A` / `git add .`.
 - Human-facing text (UI strings >1–2 words, the report, the PR body) passes through
   `humanizer` if installed. Code identifiers, dev comments, log lines, and
@@ -86,6 +104,13 @@ mechanics (verified `gh` commands, token scope, draft handling):
 - Open the files the issue points at; map the real code (functions, wiring, existing tests,
   any visual harness).
 - Confirm the base branch (Hard rules + `git branch -a`).
+- **Cut the branch inside an isolated worktree.** Create (or resume) the
+  `../<repo>-worktrees/issue-<N>` worktree, `cd` into it, and **install the project's
+  dependencies** there (a fresh worktree has only tracked files — no `node_modules`/`.venv`/etc,
+  so the Step 6 gates would fail without a setup pass) before touching any file. Full mechanics
+  (resume check, base start-point, deps, exact commands, sandbox fallback):
+  `${CLAUDE_PLUGIN_ROOT}/skills/issue-to-pr/references/worktree-and-merge.md` → "Create or
+  resume the worktree". Everything downstream runs there.
 - **Board-mode:** once the branch is cut and work begins, set the card's status to
   `in_progress` (see board-sync). A failed status write is logged and never blocks progress.
 
@@ -102,12 +127,16 @@ When in doubt, treat it as one level harder.
 
 ## Step 2.5 — Decide on state tracking
 
-- If the task is complex+ and will likely outlive a context compaction, keep a short
-  progress file in a **gitignored** location (`tmp/task-<N>/progress.md` or the session
-  scratchpad): branch, decisions, plan checklist, current step.
-- Put the **design doc there too** (`tmp/task-<N>/design.md`) unless your project commits
-  design docs under `docs/`. Treat it as a working artifact.
-- **Delete `tmp/task-<N>/` when the task is done.** It never lands in git.
+- If the task is complex+ and will likely outlive a context compaction, keep a short progress
+  file at **`tmp/task-<N>/progress.md` inside the worktree** (gitignored): branch,
+  `<original-root>`, decisions, plan checklist, current step.
+- Put the **design doc there too** (`tmp/task-<N>/design.md`) unless your project commits design
+  docs under `docs/`. Treat it as a working artifact.
+- Keep these *inside* the worktree so a resume restores them and Step 12 removes them for free
+  when the worktree is torn down. Write with an absolute path (or `cd` into the worktree first) —
+  don't assume a bare relative path lands there. Only in the sandbox-fallback (in-place) case is
+  there no worktree; then use the session scratchpad, and Step 12 sweeps it explicitly (see its
+  keep-list).
 
 ## Step 3 — Brainstorm (complex+ only)
 
@@ -169,12 +198,14 @@ a dedicated browser test — not eyeballing alone. Logic gets unit/integration t
 ## Step 9 — Commit + PR
 
 - `git add <explicit paths>`, conventional-commit subjects (separate unrelated concerns).
-- Push the branch; open a PR against the base from Step 1 with `gh pr create`. Link the
-  issue (`Closes #<N>`) so it auto-closes on merge. PR body is human-facing → humanize it.
+- Push the branch **with upstream tracking** — `git push -u origin <branch>` (Step 11's merge
+  precondition relies on it). Open a PR against the base from Step 1 with `gh pr create`. Link the
+  issue (`Closes #<N>`) so it auto-closes when the PR merges into the default branch. PR body is
+  human-facing → humanize it.
 - **Board-mode:** set the card's status to `in_review` (see board-sync). `Done` is left to
-  merge-time — GitHub's built-in project automation moves the card when the issue closes;
-  this skill does not merge.
-- Do **not** merge or deploy unless the user asks.
+  merge-time — GitHub's automation moves the card when the issue closes (on a default-branch merge).
+- The PR opens here and the skill **stops**. Merging is Step 11, gated on the user's approval
+  — do **not** merge or deploy on this turn.
 
 ## Step 10 — Report (plain language)
 
@@ -183,8 +214,52 @@ Short, human, no jargon — understandable by a 3rd-year student:
 - Test status (with the green proof) and anything the user must do by hand (manual setup,
   secrets, follow-up).
 - The PR link.
+- End with a clear hand-back: the PR is up and waiting — ask the user to reply when they want
+  it merged. Then **stop**; the skill's turn ends here.
 
-## Step 11 — Improve this skill
+## Step 11 — Merge on approval (GATE)
+
+On a later turn your CWD may have reset to the main checkout, so **return to your working tree
+first**: in worktree mode `cd` into `../<repo>-worktrees/issue-<N>`; in the sandbox in-place
+fallback there's no worktree, so stay in the main checkout on `<branch>` (the reference's "Merge on
+approval" covers both). Then read the user's reply against *this* PR. **Merge only on an unambiguous go-ahead to merge THIS PR — the burden is on a
+clear approval. If the reply is anything else, do not merge.**
+- **Go-ahead** — an unmistakable instruction to merge this PR ("merge it", "lgtm, ship it",
+  "approved", "go ahead and merge") → merge.
+- **Change requests** → treat as review feedback: implement in the worktree, then **re-run the
+  gates** — Step 6 (typecheck + tests, + visual for UI) and Step 7 (code-review) on the new diff,
+  fixing until clean — before pushing to the same branch, re-reporting, and waiting for approval
+  again. A change-request edit must clear the same gates as the original work; never merge
+  unverified changes.
+- **Anything else** → do **not** merge. If the reply is a vague acknowledgment ("ok", "cool",
+  "looks fine") or a question about the PR, ask them to confirm the merge explicitly. If the user
+  will merge it themselves later or has abandoned the task, ask whether to tear down the local
+  worktree now — via the **"Teardown without merging"** section, which removes only the local
+  worktree and **keeps the PR and its remote branch intact** (never the section-3 cleanup, which
+  deletes the remote branch and would close the open PR). Don't silently leave a stale worktree a
+  later run would resume from. There is no timeout; approval is purely explicit — never inferred.
+
+Merge mechanics and failure handling (be-in-worktree, `git push` precondition, squash by head
+branch, the single retry for pending checks, when to stop):
+`${CLAUDE_PLUGIN_ROOT}/skills/issue-to-pr/references/worktree-and-merge.md` → "Merge on
+approval". If the merge does not succeed, **skip cleanup** — the worktree and branch stay put
+so nothing is lost.
+
+## Step 12 — Cleanup (after a successful merge)
+
+Only after Step 11 merges. First confirm the outcome honestly: GitHub auto-closes the linked
+issue (and moves the board card to Done) **only on a merge into the default branch** — if the
+base was a non-default branch like `dev`, the issue stays open on purpose; say so rather than
+reporting it closed (see the reference's "Merge on approval" outcome check). Then clean up: order
+matters — you can't remove a worktree from inside it. **Salvage any lasting design doc first**
+(`git worktree remove` silently deletes gitignored files), then return to the original checkout,
+remove the worktree, delete the now-merged local + remote branch, and sweep temp artifacts outside
+the worktree — honoring the keep-list (committed `docs/`, anything already in the PR, anything the
+user asked to keep). Full sequence, in-place variant, and keep-list:
+`${CLAUDE_PLUGIN_ROOT}/skills/issue-to-pr/references/worktree-and-merge.md` → "Post-merge
+cleanup". Finish with one line naming what was merged, what was removed, and anything kept.
+
+## Step 13 — Improve this skill
 
 After shipping, reflect: did any step bite, stay unclear, or get skipped? If so, refine this
 SKILL.md. Leave it sharper than you found it.

--- a/plugins/issue-to-pr/skills/issue-to-pr/references/worktree-and-merge.md
+++ b/plugins/issue-to-pr/skills/issue-to-pr/references/worktree-and-merge.md
@@ -1,0 +1,258 @@
+# Worktree isolation, merge, and cleanup
+
+Mechanics for running each task in its own git worktree, merging the PR after the user
+approves it in-session, and cleaning up afterward. All commands are one line so they
+copy-paste into PowerShell and bash alike; paths use forward slashes. (Numbered headers below
+are **sections of this file**; the pipeline's numbered "Step N" live in `SKILL.md`.)
+
+Throughout: `<N>` is the issue number, `<branch>` the working branch
+(`feat/issue-<N>-<slug>` or `fix/issue-<N>-<slug>` — the issue number is baked in so the branch
+shares the worktree path's key and can't collide across issues), `<base>` the resolved
+integration base, `<repo>` the repo directory's basename, `<original-root>` the main repo
+checkout you started in, and `<wt>` the worktree at `../<repo>-worktrees/issue-<N>` (record its
+absolute path — you `cd` in and out of it across turns).
+
+**Resolve config and base in `<original-root>` (the main checkout), before entering the
+worktree.** The per-project `.claude/issue-to-pr.local.md` is gitignored, so it is **not** present
+in the worktree — re-reading config from inside the worktree would silently lose the pinned
+`base_branch` and test/typecheck/visual commands and fall back to auto-detect. Resolve them once
+here and carry the resolved values.
+
+## 1. Create or resume the worktree (SKILL Step 1)
+
+**Record `<original-root>` first**, while still in the main checkout:
+
+```bash
+git rev-parse --show-toplevel
+```
+
+Note it in your progress file. (If it is ever lost, section 3 shows how to recover it — do
+**not** re-run this from inside the worktree, where it returns the worktree's path.) Run every
+`git worktree` command below **from `<original-root>`** so the relative path resolves correctly.
+
+**Fetch, then resolve the base start-point.** Cut the branch from the **up-to-date remote base**,
+not a possibly-stale local ref, so the branch and the PR target share the same commits:
+
+```bash
+git fetch origin
+```
+
+Resolve `<base>` from config `base_branch`. For `auto`, use `dev` if a `dev` branch exists either
+locally or on the remote — check both (a non-empty line from either means it exists), else `main`:
+
+```bash
+git branch --list dev
+git branch -r --list origin/dev
+```
+
+(Two separate commands, not chained — `||` is a parser error in PowerShell.) Then pick the
+**`<start-point>`** to cut from: `origin/<base>` when that remote-tracking ref exists (the
+up-to-date remote base), otherwise the local `<base>` branch. Everywhere below, `<start-point>` is
+that resolved ref.
+
+**Resume check (before creating anything):**
+
+```bash
+git worktree list --porcelain
+```
+
+- An entry for `.../issue-<N>` is present:
+  - **Directory missing** (registered but deleted on disk) → `git worktree prune`, then create fresh
+    (below).
+  - **Checkout state first:** if the entry is `detached` or sits on `<base>` rather than a
+    `feat/`/`fix/` branch (no `branch refs/heads/<name>` line, or it points at `<base>`), do
+    **not** commit or resume — stop and report so the user decides.
+  - Otherwise read that entry's authoritative branch from its `branch refs/heads/<name>` line —
+    use **that** name for everything here, not one re-derived from the (possibly-edited) title.
+    Confirm the work isn't already done: `gh pr list --head <that-branch> --state all` and
+    `gh issue view <N> --json state,stateReason`. If the PR is **already merged**, the work is done
+    → run the **section-3** post-merge cleanup (remove the worktree, delete the now-merged local +
+    remote branch). If the issue is closed/abandoned with **no** merged PR → report it and offer
+    the **section-3b** teardown (keeps any open PR). Otherwise `cd` into the path, re-verify
+    dependencies are installed (a crash between create and setup, or a moved clone, leaves them
+    missing) and re-install if needed, then continue — the Step 2.5 progress + design files inside
+    the worktree are restored.
+- The path exists on disk but is **absent** from `git worktree list` → do not overwrite. Stop and
+  ask (a leftover from a crashed run, or an unrelated directory).
+
+**Create (when no worktree exists yet), from `<original-root>`:**
+
+```bash
+git worktree add "../<repo>-worktrees/issue-<N>" -b "<branch>" "<start-point>"
+```
+
+Then `cd "../<repo>-worktrees/issue-<N>"`.
+
+**Install dependencies / project setup.** A worktree holds only tracked files — gitignored deps
+(`node_modules`, `.venv`, `target`, build caches) are **not** copied, and it's a sibling dir so
+upward module resolution can't reach the main checkout's. Before the Step 6 gates can pass,
+bootstrap it the way a fresh clone is (`npm ci`/`npm install`, `pip install -r` / `poetry install`,
+`cargo build`, `go mod download`) — match the project's documented setup.
+
+**Create-failure handling.** Read the error text — three distinct causes, never conflated:
+
+- **`already exists`** (path or branch) — a concurrent run, or a leftover from a crashed run or a
+  section-3b teardown that kept the branch. **Never** a sandbox problem; **never** work in place.
+  Re-run `git worktree list --porcelain`: a worktree now at `.../issue-<N>` → resume case above; no
+  worktree but the **branch** `<branch>` already exists (e.g. kept by 3b, PR still open) →
+  re-attach a worktree to that existing branch, `git worktree add "../<repo>-worktrees/issue-<N>"
+  "<branch>"` (no `-b`), then continue; only a stale dir with no branch → stop and ask.
+- **`invalid reference` / unknown start-point** — re-resolve `<start-point>` (`git fetch`, then
+  `origin/<base>` or the local `<base>`) and retry; if the base genuinely doesn't exist, stop and
+  ask.
+- **Permission / sandbox denial** — and only this — triggers the **in-place fallback**: tell the
+  user the sandbox blocked worktree creation and work **in place** in `<original-root>`. Cut the
+  branch there (`git switch -c "<branch>" "<start-point>"`); its deps are already present. Sections
+  2 and 3 then use their in-place variants.
+
+Running the pipeline in `<original-root>` because of an `already exists`/`invalid reference` error
+would break isolation and can clobber a concurrent run's tree — never do it.
+
+## 2. Merge on approval (SKILL Step 11)
+
+Runs only after the user approves *this* PR in-session.
+
+**Get into the right tree.** A later turn may have reset your CWD.
+- **Worktree mode:** `cd "<wt>"` — all Step 11 work happens there.
+- **In-place mode** (sandbox fallback, no worktree): you are already in `<original-root>` on
+  `<branch>`; do **not** `cd` into `<wt>` (it doesn't exist).
+
+**Precondition — every local commit is on the remote,** and confirm the push actually landed
+(don't merge a stale remote head). Just push — idempotent, no upstream math (avoid `@{upstream}`,
+a hard parse error in PowerShell):
+
+```bash
+git push
+```
+
+`Everything up-to-date` or a successful push → proceed. If the push is **rejected** (non-fast-forward,
+auth) → **stop, do not merge**; resolve the push first, or the change-request commit would be
+excluded from the squash.
+
+**Merge — GitHub side only.** Target the PR by its **head branch**, never the issue number (`<N>`
+is the *issue* number; issues and PRs share one sequence, so `<N>` is never a valid PR number). Do
+**not** pass `--delete-branch` (the branch is still checked out; deletion is section 3):
+
+```bash
+gh pr merge <branch> --squash
+```
+
+If the repo disallows squash (`Squash merging is not allowed…`), use its allowed method
+(`--merge` or `--rebase`) instead and note it — the section-3 `git branch -D` still applies.
+
+**Failure handling** — read the error text:
+- **Pending required checks** (running, not failed): wait once, retry the single command once.
+- **Merge conflict, branch protection, failed checks, or a second failure:** stop, print the exact
+  `gh` error, ask how to proceed. Leave the worktree and branch intact — no cleanup runs.
+
+**After a successful merge, confirm the outcome.** GitHub's `Closes #<N>` auto-closes the issue
+(and moves the board card to Done) **only when the PR merged into the repo's default branch**. If
+`<base>` is not the default (e.g. a `dev` integration branch), the issue stays open on purpose —
+it closes later when `dev` reaches the default branch. Check and report honestly:
+
+```bash
+gh issue view <N> --json state,stateReason
+```
+
+Issue `CLOSED` → done. Issue still `OPEN` because `<base>` isn't the default → say so in the
+report (merged to `<base>`; the issue/card will close when `<base>` reaches the default branch);
+do **not** claim the issue is closed, and do not force it closed unless the user asks.
+
+Never force-push, never bypass branch protection, never merge on the same turn the PR opened.
+
+## 3. Post-merge cleanup (SKILL Step 12)
+
+Runs only after a **successful** merge.
+
+**Recover `<original-root>` if lost** — the **first** `worktree` line of `git worktree list
+--porcelain` (do **not** use `git rev-parse --show-toplevel` from inside the worktree — it returns
+the worktree path):
+
+```bash
+git worktree list --porcelain
+```
+
+**Salvage the design doc first.** `git worktree remove` silently deletes gitignored files, so a
+`tmp/task-<N>/design.md` (when the project does **not** commit design docs) would vanish without
+tripping the dirty-tree guard below. Before removing anything, if such a design doc has lasting
+value, surface its content in the final report (or copy it under `<original-root>` outside the
+worktree).
+
+Then, in order (worktree mode):
+
+```bash
+cd "<original-root>"
+git worktree remove "../<repo>-worktrees/issue-<N>"
+git branch -D "<branch>"
+git push origin --delete "<branch>"
+```
+
+- Removing the worktree first frees `<branch>`, so `git branch -D` succeeds. `-D` is safe: the
+  section-2 precondition confirmed every local commit is in the merged PR.
+- `git push origin --delete` removes the remote branch. If GitHub already auto-deleted the head,
+  this prints `remote ref does not exist` — harmless, ignore it. (This deletes the PR's head, which
+  is fine **only because the PR is already merged** — never run it on an unmerged PR; see 3b.)
+- If `git worktree remove` refuses, the worktree is **dirty** — untracked files **or** uncommitted
+  tracked modifications. Inspect explicitly (you already `cd`'d to `<original-root>`):
+  ```bash
+  git -C "../<repo>-worktrees/issue-<N>" status --porcelain
+  ```
+  - **Only untracked / disposable** (`??`) → salvage the keep-list, then
+    `git worktree remove --force "../<repo>-worktrees/issue-<N>"`.
+  - **Any modified/staged tracked file** (` M`, `M `, `A `, …) → **STOP.** That edit isn't in the
+    merged PR; `--force` would destroy it. Show the diff and ask before removing.
+
+**In-place (sandbox-fallback) variant** — no worktree to remove; `<branch>` is checked out in
+`<original-root>`, so switch off it first:
+
+```bash
+cd "<original-root>"
+git switch "<base>"
+git branch -D "<branch>"
+git push origin --delete "<branch>"
+```
+
+**Remove temp artifacts outside the worktree.** Worktree mode: the Step 2.5 `tmp/task-<N>/` dir is
+inside the worktree and already gone with it (design doc salvaged above). In-place mode: the Step
+2.5 files are in the session scratchpad — sweep them there.
+
+**Keep-list — never remove:** committed `docs/` (or wherever design docs are committed), anything
+already in the PR, anything the user asked to keep.
+
+**Confirm.** One line: what was merged, what was removed (worktree path, local + remote branch,
+temp), and anything kept.
+
+## 3b. Teardown without merging (user self-merges or abandons)
+
+When the user will merge the PR themselves later, or abandons the task, and asks to clear the local
+workspace — clear the **local** workspace only and **keep the PR intact**. Do **not** delete the
+remote branch (that would close the open PR).
+
+**Salvage any lasting design doc first** (as in section 3 — `git worktree remove` silently deletes
+gitignored files, so the salvage must precede the removal). Then:
+
+- **Worktree mode:**
+  ```bash
+  cd "<original-root>"
+  git worktree remove "../<repo>-worktrees/issue-<N>"
+  ```
+  (Dirty-tree handling as in section 3.)
+- **In-place mode** (sandbox fallback, no worktree): there is nothing to remove — leave
+  `<original-root>` on `<branch>` as-is.
+
+Either way, sweep the outside-worktree temp artifacts (the scratchpad in in-place mode), and leave
+`<branch>` and its remote head in place so the PR stays open and mergeable. Report that the PR and
+branch were kept and only the local workspace was cleared.
+
+A later re-invocation of the same issue finds no worktree but the kept `<branch>` still exists, so
+the create path's `-b <branch>` would report "already exists" — handled by the create-failure
+case above, which re-attaches a worktree to the existing branch (`git worktree add
+"../<repo>-worktrees/issue-<N>" "<branch>"`, no `-b`).
+
+## 4. What "Done" means (board-mode)
+
+`Done` is left to GitHub's built-in project automation, which moves the card when the issue
+auto-closes on merge — and that closing fires **only on a merge into the default branch** (see the
+outcome check in section 2). For a non-default `<base>`, the card advances to Done later, when
+`<base>` reaches the default branch; the skill does not set `Done` manually (that would race the
+platform).


### PR DESCRIPTION
## What this does

Updates the `issue-to-pr` skill so each run works in its own git worktree, and so the skill can merge the PR and clean up once you approve it in the session.

Two changes:

1. Worktree isolation. At Step 1 the skill cuts its branch inside a dedicated `../<repo>-worktrees/issue-<N>` worktree and does all its work there, so several local agents can drive different issues in the same clone without stepping on each other.

2. Approval-gated merge and cleanup. The PR opens and the skill stops. Once you reply with an explicit go-ahead like "merge it" or "lgtm ship it", it squash-merges the PR by its head branch, then tears down the worktree, the local and remote branch, and the run's temp artifacts. Anything important, or anything you told it to keep, stays.

## How it was verified

There's no executable code here, it's an instructional skill, so verification was a design cross-review plus three code-review passes. Those passes caught and drove fixes for a batch of real problems: a `@{upstream}` check that's a parse error in PowerShell and could have silently dropped commits during the squash, teardown that failed because the branch was still checked out, a fresh worktree with no dependencies installed so the test gate could never go green, config that lives outside the worktree, base resolution cutting from a stale local ref, and `Closes #N` not firing when the base is a non-default branch like `dev`.

## Notes

- Merge is squash, and only on an explicit in-session approval, never on the turn the PR opens.
- The `.claude/issue-to-pr.local.md` config, the base branch, and the test commands are resolved in the main checkout before entering the worktree.
- Version bumped to 1.1.0 with a changelog entry; both READMEs updated.

https://claude.ai/code/session_01S6zvJxpKZBXEQc5wM9v1DT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clarified the `issue-to-pr` workflow to use isolated worktrees per task, reducing local conflicts.
  * Added an approval-gated merge flow with squash-merge, branch removal, worktree teardown, and temp-file cleanup after approval.
  * Improved status guidance so board and issue states are easier to follow from work start through completion.

* **Documentation**
  * Updated plugin docs and changelog to reflect the latest workflow behavior.
  * Bumped the plugin version to `1.1.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->