### PR TITLE
fix(issue-to-pr): reliable worktree cleanup on Windows (v1.2.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -130,7 +130,7 @@
     {
       "name": "issue-to-pr",
       "description": "Drive a GitHub issue — bare or tracked on a Project board — from triage to a merge-ready PR through a worktree-isolated, gated pipeline (design cross-review, tests green, code-review loop). After you approve the PR in-session it squash-merges and cleans up the branch, worktree, and temp artifacts. Auto-links the issue to close on merge and advances the board card's status as work progresses",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "author": {
         "name": "Dmitry Yuhanov"
       },

--- a/plugins/issue-to-pr/.claude-plugin/plugin.json
+++ b/plugins/issue-to-pr/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "issue-to-pr",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Drive a GitHub issue — bare or tracked on a Project board — from triage to a merge-ready PR through a worktree-isolated, gated pipeline (design cross-review, tests green, code-review loop). After you approve the PR in-session it squash-merges and cleans up the branch, worktree, and temp artifacts. Auto-links the issue to close on merge and advances the board card's status as work progresses",
   "author": {
     "name": "Dmitry Yuhanov"

--- a/plugins/issue-to-pr/CHANGELOG.md
+++ b/plugins/issue-to-pr/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the **issue-to-pr** plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.2.1] - 2026-07-04
+
+### Fixed
+- Post-merge cleanup no longer stalls on Windows and leaves the merged branch behind
+
 ## [1.2.0] - 2026-07-03
 
 ### Added

--- a/plugins/issue-to-pr/scripts/worktree.sh
+++ b/plugins/issue-to-pr/scripts/worktree.sh
@@ -46,8 +46,11 @@ compute_wt_path() { # root issue
   printf '%s/%s-worktrees/issue-%s' "$(dirname "$1")" "$(basename "$1")" "$2"
 }
 
-registered_wt() { # issue -> registered worktree path ending in /issue-<N>, or empty
-  git worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p' | grep -E "/issue-$1\$" | head -1
+registered_wt() { # issue [root] -> registered worktree path ending in /issue-<N>, or empty
+  (
+    if [ -n "${2:-}" ]; then cd "$2" || exit 0; fi
+    git worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p' | grep -E "/issue-$1\$" | head -1
+  )
 }
 
 branch_exists() { git show-ref --verify --quiet "refs/heads/$1"; }
@@ -81,13 +84,39 @@ salvage_artifacts() { # wt salvage_dir issue -> sets SALVAGED
   SALVAGED=$dst
 }
 
-# remove_worktree wt root issue -> sets REMOVED; STOPs on tracked dirtiness.
-# Never uses --force: a refused removal is classified from `git status --porcelain`.
+# remove_worktree wt root issue -> sets REMOVED and (on a stubborn dir) LEFTOVER.
+# Never uses --force, never STOPs on a merely-locked dir, and never auto-deletes an
+# UNREGISTERED directory (same protection as ensure's stale-unregistered-dir): git
+# only ever unregisters a clean worktree, but an unregistered path could also be a
+# stale remnant or something the user parked there, so we report it instead of
+# deleting it. STOPs only on tracked/unexpected changes in a still-registered tree.
 remove_worktree() {
   local wt=$1 root=$2 n=$3
   REMOVED=false
+  LEFTOVER=""
+
+  # Nothing on disk: just tidy git's records.
+  if [ ! -e "$wt" ]; then
+    git -C "$root" worktree prune 2>/dev/null || true
+    REMOVED=true
+    return 0
+  fi
+
   if git -C "$root" worktree remove "$wt" 2>/dev/null; then REMOVED=true; return 0; fi
 
+  # Removal refused. If the worktree is NO LONGER registered, git partially
+  # succeeded (unregistered it on Windows but a lock left the directory) or it was
+  # never a worktree. Either way, do not delete it - prune git's records and report
+  # the leftover so the model/user can inspect and remove it deliberately.
+  local still_reg
+  still_reg=$(registered_wt "$n" "$root")
+  if [ -z "$still_reg" ]; then
+    git -C "$root" worktree prune 2>/dev/null || true
+    LEFTOVER="$wt"
+    return 0
+  fi
+
+  # Still registered: refused because the tree is dirty. Classify.
   local status line p tracked_dirty=0
   # --untracked-files=all so an untracked tmp/ is listed as individual files
   # (tmp/task-N/foo), not collapsed to a bare "?? tmp/" that would misclassify.
@@ -116,7 +145,11 @@ EOF
   # Only our tmp working dir was in the way: remove it explicitly, retry once.
   rm -rf "${wt:?}/tmp/task-$n" 2>/dev/null || true
   if git -C "$root" worktree remove "$wt" 2>/dev/null; then REMOVED=true; return 0; fi
-  stop worktree-remove-failed "could not remove $wt cleanly (no --force is ever used)"
+  # Clean but still un-removable (a lock persists): report, do not STOP - the branch
+  # and marker can still be cleaned up. Run cleanup from the main checkout to avoid
+  # this (a shell whose cwd is the worktree locks it on Windows).
+  LEFTOVER="$wt"
+  return 0
 }
 
 # -- subcommands --------------------------------------------------------------
@@ -301,9 +334,10 @@ cmd_cleanup() {
   cd "$root" 2>/dev/null || true
 
   REMOVED=false
-  if [ -n "$reg" ]; then
-    remove_worktree "$wt_path" "$root" "$issue"
-  fi
+  LEFTOVER=""
+  # remove_worktree also handles an unregistered leftover dir (reports it via
+  # LEFTOVER, never deletes it), so call it unconditionally from the main checkout.
+  remove_worktree "$wt_path" "$root" "$issue"
 
   local deleted_local=false deleted_remote=false
   # In-place mode (no worktree): the branch may be checked out in root, and a
@@ -335,6 +369,7 @@ cmd_cleanup() {
   emit DELETED_LOCAL "$deleted_local"
   emit DELETED_REMOTE "$deleted_remote"
   emit SALVAGED "${SALVAGED:-}"
+  [ -n "$LEFTOVER" ] && emit LEFTOVER_DIR "$LEFTOVER"
   done_ok
 }
 
@@ -358,11 +393,11 @@ cmd_teardown() {
   cd "$root" 2>/dev/null || true
 
   REMOVED=false
-  if [ -n "$reg" ]; then
-    remove_worktree "$wt_path" "$root" "$issue"
-  fi
+  LEFTOVER=""
+  remove_worktree "$wt_path" "$root" "$issue"
   emit REMOVED "$REMOVED"
   emit SALVAGED "${SALVAGED:-}"
+  [ -n "$LEFTOVER" ] && emit LEFTOVER_DIR "$LEFTOVER"
   emit KEPT "branch-and-pr" # teardown never touches the branch or PR
   done_ok
 }

--- a/plugins/issue-to-pr/skills/issue-to-pr/SKILL.md
+++ b/plugins/issue-to-pr/skills/issue-to-pr/SKILL.md
@@ -266,11 +266,15 @@ Only after Step 11 merges. First confirm the outcome honestly: GitHub auto-close
 issue (and moves the board card to Done) **only on a merge into the default branch** — if the
 base was a non-default branch like `dev`, the issue stays open on purpose; say so rather than
 reporting it closed (see the reference's "Merge on approval" outcome check). Then clean up: order
-matters — you can't remove a worktree from inside it. **Salvage any lasting design doc first**
+matters — you can't remove a worktree from inside it. **`cd` your shell into `<original-root>`
+first** (not just the subprocess — a shell whose current directory is the worktree locks it on
+Windows and the removal fails). **Salvage any lasting design doc first**
 (`git worktree remove` silently deletes gitignored files), then, from the main checkout, run
 `${CLAUDE_PLUGIN_ROOT}/scripts/worktree.sh cleanup <N> --branch <branch> --salvage-to <dir>` (it
 salvages design/progress/state, removes the worktree, deletes the merged local + remote branch,
-and refuses on tracked dirtiness `STOP_REASON=dirty-tracked-files`), and sweep temp artifacts outside
+and refuses on tracked dirtiness `STOP_REASON=dirty-tracked-files`). Report from its keys, not from
+assumption — if `DELETED_LOCAL=false` or it emits `LEFTOVER_DIR`, a locked directory remains; say so
+and remove it by hand once the lock clears. Then sweep temp artifacts outside
 the worktree — honoring the keep-list (committed `docs/`, anything already in the PR, anything the
 user asked to keep). Keys, the in-place variant, and the teardown (self-merge/abandon) path:
 `${CLAUDE_PLUGIN_ROOT}/skills/issue-to-pr/references/contracts.md` → "worktree.sh".

--- a/plugins/issue-to-pr/skills/issue-to-pr/references/contracts.md
+++ b/plugins/issue-to-pr/skills/issue-to-pr/references/contracts.md
@@ -62,11 +62,17 @@ push-rejected · checks-pending · merge-failed`. On any stop, nothing is cleane
 Hard precondition: the PR is `MERGED` (else stop `pr-not-merged` — deleting an open PR's branch is
 mechanically impossible). Salvages `tmp/task-<N>/{design,progress,state}` first, removes the
 worktree (never `--force`; tracked dirtiness → stop `dirty-tracked-files`), deletes the local +
-remote branch, removes the marker. Keys: `REMOVED DELETED_LOCAL DELETED_REMOTE SALVAGED`.
+remote branch, removes the marker. Keys: `REMOVED DELETED_LOCAL DELETED_REMOTE SALVAGED`, plus
+`LEFTOVER_DIR` if a directory could not be removed. **Run it with your shell's cwd in
+`<original-root>`, not the worktree** — a shell sitting inside the worktree locks it on Windows so
+`git worktree remove` only partially succeeds. Cleanup never auto-deletes an unregistered
+directory (same protection as `ensure`): it reports the path as `LEFTOVER_DIR` and still removes
+the marker + remote branch. Check `DELETED_LOCAL` — if a still-registered locked worktree remains
+it stays `false`; delete that branch and the leftover yourself once whatever holds it is gone.
 
 `worktree.sh teardown <N> [--salvage-to <dir>]` — user self-merges / abandons. Removes the
 worktree only; **never touches the branch or PR**. Keys: `REMOVED SALVAGED KEPT`
-(`branch-and-pr | in-place`).
+(`branch-and-pr | in-place`), plus `LEFTOVER_DIR` if a directory could not be removed.
 
 ## Merge-approval gate — the physics
 

--- a/plugins/issue-to-pr/tests/contract/test_worktree.sh
+++ b/plugins/issue-to-pr/tests/contract/test_worktree.sh
@@ -252,6 +252,24 @@ test_wt_cleanup_in_place_deletes_checked_out_branch() {
   fi
 }
 
+test_wt_cleanup_reports_unregistered_leftover_dir() {
+  # A directory at the worktree path that git no longer tracks (a prior
+  # partial-success remnant on Windows, or a folder parked there) must be REPORTED,
+  # not silently deleted, while branch + marker cleanup still proceeds.
+  local repo wt; repo=$(mk_repo); wt=$(mk_worktree "$repo" feat/issue-6-x); cd "$repo"
+  git -C "$repo" worktree remove "$wt"
+  mkdir -p "$wt"
+  printf 'stale\n' >"$wt/leftover"
+  use_fake_gh pr-merged
+  run_script worktree.sh cleanup 6 --branch feat/issue-6-x
+  assert_rc 0
+  # LEFTOVER_DIR is emitted (exact path format is git's, not the test's cygwin form).
+  assert_key_present "$OUT" LEFTOVER_DIR
+  assert_contains "$OUT" "issue-6"
+  assert_key "$OUT" DELETED_LOCAL true # branch cleanup still runs
+  if [ ! -d "$wt" ]; then fail "unregistered dir must be reported, not deleted"; fi
+}
+
 # ── teardown ────────────────────────────────────────────────────────────────
 test_wt_teardown_removes_but_keeps_branch() {
   local repo wt; repo=$(mk_repo); wt=$(mk_worktree "$repo" feat/issue-6-x); cd "$repo"


### PR DESCRIPTION
Closes #8

A follow-up to v1.2.0. On Windows, `git worktree remove` can partially succeed after a merge: it unregisters the worktree but can't delete the directory while a process still holds it, usually the shell's own current directory sitting inside the worktree at merge time. The old cleanup then dead-ended and left the merged branch behind.

## The fix

- `remove_worktree` never deletes a directory git hasn't already removed. An unregistered leftover is pruned from git's records and reported as a new `LEFTOVER_DIR` key, never `rm`'d. That matches the protection `ensure` already gives a stale unregistered directory.
- Cleanup and teardown no longer stop on a locked or unregistered leftover: they still delete the branch and marker and surface `LEFTOVER_DIR` for you to remove once the lock clears. Check `DELETED_LOCAL`; it stays `false` if a still-registered locked worktree holds the branch.
- The leftover handling now lives in one place (`remove_worktree`), called by both cleanup and teardown, instead of three copies.
- SKILL Step 12 and contracts.md tell the model to run cleanup with its shell in the main checkout, which is the lock's real cause.

## Verification

- 93 contract tests green (a new one covers the report-not-delete behavior); shellcheck clean.
- Two rounds of adversarial code review. The first caught the risky first draft, which would have silently `rm -rf`'d an unregistered directory. The rework passed the second with no runtime findings.

This is the exact bug hit while merging #7. The merge there was fine; only the teardown was left half-done.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup after merges so locked or stale worktrees no longer cause the process to stall, especially on Windows.
  * Cleanup now handles leftover local directories more gracefully and reports them clearly when manual removal is still needed.

* **Documentation**
  * Updated merge and cleanup guidance to reflect the new behavior and recovery steps.

* **Tests**
  * Added coverage for cleanup scenarios involving unregistered leftover directories.

* **Chores**
  * Bumped the plugin version to 1.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->