### PR TITLE
feat(issue-to-pr): autonomy + cost-scaling layer (v1.3.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -129,8 +129,8 @@
     },
     {
       "name": "issue-to-pr",
-      "description": "Drive a GitHub issue — bare or tracked on a Project board — from triage to a merge-ready PR through a worktree-isolated, gated pipeline (design cross-review, tests green, code-review loop). After you approve the PR in-session it squash-merges and cleans up the branch, worktree, and temp artifacts. Auto-links the issue to close on merge and advances the board card's status as work progresses",
-      "version": "1.2.1",
+      "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp files; the issue auto-closes on merge and the board card advances as work moves.",
+      "version": "1.3.0",
       "author": {
         "name": "Dmitry Yuhanov"
       },

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,5 @@
 # issue-to-pr ships bash scripts that must run under Git Bash on Windows and in
 # Linux CI. Force LF on the whole tree, including the extension-less fake-gh
 # shim (CRLF is the number-one way these break on the author's own machine).
-plugins/issue-to-pr/scripts/** text eol=lf
-plugins/issue-to-pr/tests/** text eol=lf
+plugins/issue-to-pr/** text eol=lf
 plugins/issue-to-pr/tests/fake-gh/gh text eol=lf

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Drive a single GitHub issue from triage to a merge-ready pull request through a 
 - One flow for a **bare issue** or a **card on a GitHub Projects (v2) board** — Step 0 resolves the input and decides whether board-status sync applies.
 - Each run works in its own `../<repo>-worktrees/issue-<N>` git worktree, so concurrent local agents on different issues never clash.
 - Hard gates that block forward progress: design hardening (cross-review or a multi-agent fallback), tests green (typecheck + tests, plus visual checks for UI), and a code-review loop that runs until clean or five passes.
+- Scales the work to the task's **tier** (trivial through epic): research depth, design (an autonomous design panel for complex work), review level, and report length all size to the issue — and it asks **at most one batched question**, deciding everything else itself and surfacing those decisions in the report and PR.
 - Opens the PR and stops; once you approve it in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp artifacts (keeping anything important).
 - The PR auto-links the issue (`Closes #N`) to close on merge; board cards advance to *in-progress* at branch cut and *in-review* at PR open, with `Done` left to GitHub's merge-time automation.
 - Graceful by default — missing the `project` token scope degrades to link-only, and a failed status write never blocks the PR.

--- a/plugins/issue-to-pr/.claude-plugin/plugin.json
+++ b/plugins/issue-to-pr/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "issue-to-pr",
-  "version": "1.2.1",
-  "description": "Drive a GitHub issue — bare or tracked on a Project board — from triage to a merge-ready PR through a worktree-isolated, gated pipeline (design cross-review, tests green, code-review loop). After you approve the PR in-session it squash-merges and cleans up the branch, worktree, and temp artifacts. Auto-links the issue to close on merge and advances the board card's status as work progresses",
+  "version": "1.3.0",
+  "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp files; the issue auto-closes on merge and the board card advances as work moves.",
   "author": {
     "name": "Dmitry Yuhanov"
   }

--- a/plugins/issue-to-pr/CHANGELOG.md
+++ b/plugins/issue-to-pr/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the **issue-to-pr** plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.3.0] - 2026-07-06
+
+### Added
+- Tier scaling — the pipeline sizes research, design, review depth, and the report to the task's tier (trivial through epic), chosen deterministically from the issue's signals
+- Ask contract — at most one batched question per run; every other decision is made autonomously and surfaced in the report and the PR body
+- Autonomous design panel (three proposers, two adversarial critics, a judge) replaces the one-question-at-a-time brainstorming interview for complex work
+- Forked research that keeps raw exploration out of context, plus a security-review overlay that triggers on sensitive paths
+- Self-writing config that pins verified gate commands, and a `/issue-to-pr:tune` skill that turns a friction log into batched improvements
+- A hook that denies `git add -A` / `.`, keeping staging explicit
+
+### Changed
+- SKILL trimmed to a lean ~140-line spine now that tested scripts own the mechanics; per-task state enables deterministic resume after a context compaction
+
 ## [1.2.1] - 2026-07-04
 
 ### Fixed

--- a/plugins/issue-to-pr/hooks/hooks.json
+++ b/plugins/issue-to-pr/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "issue-to-pr merge-approval gate. A PreToolUse hook on Bash routes every command through merge-guard.sh, which allows `gh pr merge` / `worktree.sh merge` only when a fresh, unused, head-matching approval marker exists (written by approve.sh after the model judges the user's reply an unambiguous go-ahead), denies `gh pr merge --admin`, asks on force-push, and passes every other command through to the normal permission flow. Plugin agents ignore hooks, so this protects the main session only -- merges must run there.",
+  "description": "issue-to-pr safety gates. Two PreToolUse hooks on Bash run in parallel: merge-guard.sh allows `gh pr merge` / `worktree.sh merge` only with a fresh, unused, head-matching approval marker (written by approve.sh after the model judges the user's reply an unambiguous go-ahead), denies `gh pr merge --admin`, and asks on force-push; stage-guard.sh denies `git add -A` / `--all` / `.` so staging stays explicit. Both pass every other command through to the normal permission flow. Plugin agents ignore hooks, so these protect the main session only -- merges must run there.",
   "hooks": {
     "PreToolUse": [
       {
@@ -8,6 +8,11 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/merge-guard.sh\"",
+            "timeout": 20
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/stage-guard.sh\"",
             "timeout": 20
           }
         ]

--- a/plugins/issue-to-pr/scripts/lib/common.sh
+++ b/plugins/issue-to-pr/scripts/lib/common.sh
@@ -152,6 +152,48 @@ gh_field() {
   gh "$@" 2>/dev/null || printf ''
 }
 
+# -- Frontmatter parser (shared by preflight.sh + pin-config.sh) --------------
+# trim_quotes STRING - strip surrounding whitespace and one layer of matching quotes.
+trim_quotes() {
+  local v=$1
+  v=${v#"${v%%[![:space:]]*}"}
+  v=${v%"${v##*[![:space:]]}"}
+  case "$v" in
+    \"*\") v=${v#\"}; v=${v%\"} ;;
+    \'*\') v=${v#\'}; v=${v%\'} ;;
+  esac
+  printf '%s' "$v"
+}
+
+# parse_frontmatter FILE CALLBACK - read a `.local.md` YAML-frontmatter subset
+# (top-level scalars + one nesting level; CRLF-tolerant) and invoke
+# `CALLBACK <top> <sub> <value>` per key (sub="" for a top-level scalar). Returns
+# 1 on a structurally-invalid frontmatter line, 0 otherwise. Sharing this keeps
+# preflight (read config) and pin-config (idempotent append) from diverging.
+parse_frontmatter() {
+  local file=$1 cb=$2 in_fm=0 cur_top="" line val
+  while IFS= read -r line || [ -n "$line" ]; do
+    line=${line%$'\r'}
+    if [ "$in_fm" = 0 ]; then
+      [ "$line" = "---" ] && in_fm=1
+      continue
+    fi
+    [ "$line" = "---" ] && return 0
+    case "$line" in '' | '#'*) continue ;; esac
+    if [[ "$line" =~ ^([A-Za-z_][A-Za-z0-9_]*):[[:space:]]*(.*)$ ]]; then
+      cur_top=${BASH_REMATCH[1]}
+      val=$(trim_quotes "${BASH_REMATCH[2]}")
+      [ -n "$val" ] && "$cb" "$cur_top" "" "$val"
+    elif [[ "$line" =~ ^[[:space:]]+([A-Za-z_][A-Za-z0-9_]*):[[:space:]]*(.*)$ ]]; then
+      [ -n "$cur_top" ] || return 1
+      "$cb" "$cur_top" "${BASH_REMATCH[1]}" "$(trim_quotes "${BASH_REMATCH[2]}")"
+    else
+      return 1
+    fi
+  done <"$file"
+  return 0
+}
+
 # repo_root - the main working tree (first `git worktree list` entry), falling
 # back to the toplevel of cwd. Empty string if not inside a git repository. The
 # approval marker lives under this root, so it is shared across worktrees.
@@ -198,4 +240,53 @@ marker_used() {
 marker_set_used() {
   local file=$1 tmp="$1.tmp"
   sed 's/"used":false/"used":true/' "$file" >"$tmp" && mv "$tmp" "$file"
+}
+
+# -- PreToolUse hook helpers (shared by merge-guard.sh + stage-guard.sh) -------
+# hook_decision DECISION REASON - emit a PreToolUse permission decision.
+hook_decision() {
+  local r
+  r=$(json_escape "$2")
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"%s","permissionDecisionReason":"%s"},"systemMessage":"%s"}\n' \
+    "$1" "$r" "$r"
+}
+hook_allow() { hook_decision allow "$1"; exit 0; }
+hook_deny() { hook_decision deny "$1"; exit 0; }
+hook_ask() { hook_decision ask "$1"; exit 0; }
+# hook_passthrough - NOT a guarded command; emit no permissionDecision so Claude
+# Code's normal permission flow handles it (returning "allow" would auto-approve
+# every Bash command the hook sees, since it matches the whole Bash tool).
+hook_passthrough() { printf '{"continue":true,"suppressOutput":true}\n'; exit 0; }
+
+# hook_extract_command JSON -> the tool_input.command value, JSON-unescaped. A
+# pure-bash scanner (no jq/perl) that honours backslash escapes, so a quoted path
+# ("D:/Code Stage/...") or an embedded quote can't truncate the command the way a
+# naive "[^"]*" match would.
+hook_extract_command() {
+  local s=$1 after out="" i n c esc=0 key='"command"'
+  case "$s" in *"$key"*) : ;; *) printf ''; return ;; esac
+  after=${s#*"$key"}
+  after=${after#*:}
+  after=${after#"${after%%[![:space:]]*}"}
+  case "$after" in \"*) after=${after#\"} ;; *) printf ''; return ;; esac
+  n=${#after}
+  for ((i = 0; i < n; i++)); do
+    c=${after:i:1}
+    if [ "$esc" = 1 ]; then
+      case "$c" in
+        n) out+=$'\n' ;;
+        t) out+=$'\t' ;;
+        r) out+=$'\r' ;;
+        *) out+=$c ;;
+      esac
+      esc=0
+    elif [ "$c" = "\\" ]; then
+      esc=1
+    elif [ "$c" = '"' ]; then
+      break
+    else
+      out+=$c
+    fi
+  done
+  printf '%s' "$out"
 }

--- a/plugins/issue-to-pr/scripts/merge-guard.sh
+++ b/plugins/issue-to-pr/scripts/merge-guard.sh
@@ -16,52 +16,8 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=lib/common.sh
 source "$SCRIPT_DIR/lib/common.sh"
 
-emit_decision() { # decision reason
-  local r
-  r=$(json_escape "$2")
-  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"%s","permissionDecisionReason":"%s"},"systemMessage":"%s"}\n' \
-    "$1" "$r" "$r"
-}
-allow() { emit_decision allow "$1"; exit 0; }
-deny() { emit_decision deny "$1"; exit 0; }
-ask() { emit_decision ask "$1"; exit 0; }
-# passthrough: NOT a guarded command. Emit no permissionDecision so Claude Code's
-# normal permission flow handles it -- returning "allow" here would auto-approve
-# every Bash command the hook sees (it matches the whole Bash tool).
-passthrough() { printf '{"continue":true,"suppressOutput":true}\n'; exit 0; }
-
-# extract_command JSON -> the tool_input.command value, JSON-unescaped. A pure-bash
-# scanner (no jq/perl dependency in the hot path) that honours backslash escapes,
-# so a quoted script path ("D:/Code Stage/...") or an embedded quote can't truncate
-# the command the way a naive "[^"]*" match would.
-extract_command() {
-  local s=$1 after out="" i n c esc=0 key='"command"'
-  case "$s" in *"$key"*) : ;; *) printf ''; return ;; esac
-  after=${s#*"$key"}
-  after=${after#*:}                              # past the colon
-  after=${after#"${after%%[![:space:]]*}"}       # ltrim whitespace
-  case "$after" in \"*) after=${after#\"} ;; *) printf ''; return ;; esac
-  n=${#after}
-  for ((i = 0; i < n; i++)); do
-    c=${after:i:1}
-    if [ "$esc" = 1 ]; then
-      case "$c" in
-        n) out+=$'\n' ;;
-        t) out+=$'\t' ;;
-        r) out+=$'\r' ;;
-        *) out+=$c ;;
-      esac
-      esc=0
-    elif [ "$c" = "\\" ]; then
-      esc=1
-    elif [ "$c" = '"' ]; then
-      break
-    else
-      out+=$c
-    fi
-  done
-  printf '%s' "$out"
-}
+# hook helpers (hook_decision/allow/deny/ask/passthrough/extract_command) live in
+# lib/common.sh, shared with stage-guard.sh.
 
 # merge_branch_of COMMAND -> the branch a `gh pr merge` targets: the first
 # non-flag positional (skipping value-taking flags), else the current HEAD.
@@ -85,10 +41,10 @@ input=$(cat)
 # normal permission flow without the char-scan.
 case "$input" in
   *merge* | *push*) : ;;
-  *) passthrough ;;
+  *) hook_passthrough ;;
 esac
 
-cmd=$(extract_command "$input")
+cmd=$(hook_extract_command "$input")
 # Collapse whitespace runs, then strip quotes, so odd spacing (`gh  pr  merge`) and
 # a quoted script path (`"...worktree.sh" merge`, which would otherwise hide the
 # `worktree.sh merge` substring) can't slip a merge command past the matchers. A
@@ -97,13 +53,13 @@ cmd=$(printf '%s' "$cmd" | tr -s '[:space:]' ' ' | tr -d '\042\047')
 
 # Never allow an admin bypass of branch protection.
 case "$cmd" in
-  *"gh pr merge"*"--admin"*) deny "gh pr merge --admin is forbidden - never bypass branch protection. Merge normally after approval." ;;
+  *"gh pr merge"*"--admin"*) hook_deny "gh pr merge --admin is forbidden - never bypass branch protection. Merge normally after approval." ;;
 esac
 
 # A force-push is a human call: match --force, -f, or a +refspec.
 case "$cmd" in
   *"git push"*"--force"* | *"git push"*" -f"* | *"git push"*" +"*)
-    ask "force-push detected - confirm this manually." ;;
+    hook_ask "force-push detected - confirm this manually." ;;
 esac
 
 # Identify the guarded merge command and its target branch.
@@ -120,23 +76,23 @@ case "$cmd" in
 esac
 
 # Anything that is not a guarded merge command defers to normal permission flow.
-[ -n "$branch" ] || passthrough
+[ -n "$branch" ] || hook_passthrough
 
 root=$(repo_root)
 marker=$(marker_path "$root" "$branch")
 
-[ -f "$marker" ] || deny "no approval marker for $branch. The model must run approve.sh after judging the reply an unambiguous go-ahead. You can still merge manually in a terminal."
+[ -f "$marker" ] || hook_deny "no approval marker for $branch. The model must run approve.sh after judging the reply an unambiguous go-ahead. You can still merge manually in a terminal."
 used=$(marker_used "$marker")
-[ "$used" = false ] || deny "the approval for $branch was already used (single-use). Re-approve to merge again."
+[ "$used" = false ] || hook_deny "the approval for $branch was already used (single-use). Re-approve to merge again."
 created=$(marker_str_field "$marker" created_at)
 epoch=$(epoch_of "$created")
-[ -n "$epoch" ] || deny "the approval marker timestamp is unparseable. Re-approve."
+[ -n "$epoch" ] || hook_deny "the approval marker timestamp is unparseable. Re-approve."
 age=$(($(now_epoch) - epoch))
-[ "$age" -le 1800 ] || deny "the approval for $branch is stale (>30 min old). Re-approve."
+[ "$age" -le 1800 ] || hook_deny "the approval for $branch is stale (>30 min old). Re-approve."
 marker_sha=$(marker_str_field "$marker" pr_head_sha)
 cur_sha=$(gh pr view "$branch" --json headRefOid --jq .headRefOid 2>/dev/null || printf '')
 if [ -z "$cur_sha" ] || [ "$marker_sha" != "$cur_sha" ]; then
-  deny "the PR head for $branch moved since approval. Re-approve so the marker matches the new head."
+  hook_deny "the PR head for $branch moved since approval. Re-approve so the marker matches the new head."
 fi
 
 # On the direct `gh pr merge` path, consume the marker now so one approval buys one
@@ -144,4 +100,4 @@ fi
 if [ "$is_gh_merge" = 1 ]; then
   marker_set_used "$marker"
 fi
-allow "approval marker for $branch is valid (present, unused, fresh, head-SHA matches)."
+hook_allow "approval marker for $branch is valid (present, unused, fresh, head-SHA matches)."

--- a/plugins/issue-to-pr/scripts/pin-config.sh
+++ b/plugins/issue-to-pr/scripts/pin-config.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# pin-config.sh - self-writing config (spec sec 5.6). After a run whose auto-detected
+# gate commands passed, pin them to .claude/issue-to-pr.local.md so later runs skip
+# detection. NEVER overwrites a human-set value: idempotency is checked with the SAME
+# shared frontmatter parser preflight uses, so a nested `commands:` value counts as
+# already-set (design D6). Base branch is never auto-pinned.
+#
+#   pin-config.sh --config <path> [--test <cmd>] [--typecheck <cmd>] [--visual <cmd>] [--smoke <cmd>]
+#
+# Emits PINNED=<comma-list of keys added> and CONFIG=<path>. Exit 0; 4 (degraded) if
+# an existing config's frontmatter cannot be parsed (never corrupt a hand-edited file).
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+config=""
+val_test="" val_typecheck="" val_visual="" val_smoke=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --config) config=${2:-}; shift 2 2>/dev/null || shift "$#" ;;
+    --test) val_test=${2:-}; shift 2 2>/dev/null || shift "$#" ;;
+    --typecheck) val_typecheck=${2:-}; shift 2 2>/dev/null || shift "$#" ;;
+    --visual) val_visual=${2:-}; shift 2 2>/dev/null || shift "$#" ;;
+    --smoke) val_smoke=${2:-}; shift 2 2>/dev/null || shift "$#" ;;
+    --json) enable_json; shift ;;
+    -*) warn "pin-config: ignoring unknown flag: $1"; shift ;;
+    *) shift ;;
+  esac
+done
+
+[ -n "$config" ] || degrade missing-config "pin-config: --config <path> required"
+
+# Record which command keys are already set, in EITHER the top-level *_cmd form or
+# the nested commands: form (both are what preflight accepts).
+has_test=0 has_typecheck=0 has_visual=0 has_smoke=0
+record() {
+  case "$1:$2" in
+    test_cmd: | commands:test) has_test=1 ;;
+    typecheck_cmd: | commands:typecheck) has_typecheck=1 ;;
+    visual_cmd: | commands:visual) has_visual=1 ;;
+    smoke_cmd: | commands:smoke) has_smoke=1 ;;
+  esac
+}
+if [ -f "$config" ]; then
+  parse_frontmatter "$config" record || degrade config-parse-failed "pin-config: cannot parse $config frontmatter - refusing to edit it"
+fi
+
+# Build the lines to append for each requested, unset command.
+block=""
+pinned=()
+maybe_pin() { # key has-flag value
+  local key=$1 already=$2 value=$3
+  [ -n "$value" ] || return 0
+  [ "$already" = 0 ] || return 0
+  block="${block}${key}_cmd: ${value}"$'\n'
+  pinned+=("$key")
+}
+maybe_pin test "$has_test" "$val_test"
+maybe_pin typecheck "$has_typecheck" "$val_typecheck"
+maybe_pin visual "$has_visual" "$val_visual"
+maybe_pin smoke "$has_smoke" "$val_smoke"
+
+if [ -z "$block" ]; then
+  emit PINNED ""
+  emit CONFIG "$config"
+  done_ok
+fi
+
+mkdir -p "$(dirname "$config")" 2>/dev/null || true
+
+# Persist the block. Both paths write to a temp first and are STATUS-CHECKED: if
+# the write cannot land (parent is a file, or a read-only/full filesystem),
+# degrade (exit 4) rather than falsely emitting PINNED - a could-not-persist must
+# never report success (exit-code contract), and a bad temp never clobbers a
+# hand-edited config.
+if [ -f "$config" ] && [ "$(grep -c '^---[[:space:]]*$' "$config")" -ge 1 ]; then
+  # Insert the new keys right after the OPENING fence (top of the frontmatter).
+  # Keying on >=1 fence matches parse_frontmatter, which accepts a single
+  # unterminated fence (EOF closes it) - so a hand-edited one-fence config is
+  # amended in place, never wrapped/orphaned. ENVIRON (not awk -v) carries the
+  # block so a backslash in a gate command is written verbatim, not escape-processed.
+  tmp="$config.tmp.$$"
+  if ADD_BLOCK="$block" awk '
+      { print }
+      /^---[[:space:]]*$/ && !inserted { printf "%s", ENVIRON["ADD_BLOCK"]; inserted = 1 }
+    ' "$config" >"$tmp" && mv "$tmp" "$config"; then :; else
+    rm -f "$tmp" 2>/dev/null || true
+    degrade config-write-failed "pin-config: could not write $config"
+  fi
+else
+  # No frontmatter yet: create one, preserving any existing notes below it.
+  existing=""
+  [ -f "$config" ] && existing=$(cat "$config")
+  suffix=""
+  [ -n "$existing" ] && suffix=$'\n'"$existing"$'\n'
+  tmp="$config.tmp.$$"
+  if printf -- '---\n%s---\n%s' "$block" "$suffix" >"$tmp" && mv "$tmp" "$config"; then :; else
+    rm -f "$tmp" 2>/dev/null || true
+    degrade config-write-failed "pin-config: could not write $config"
+  fi
+fi
+
+emit PINNED "$(join_by , "${pinned[@]}")"
+emit CONFIG "$config"
+done_ok

--- a/plugins/issue-to-pr/scripts/preflight.sh
+++ b/plugins/issue-to-pr/scripts/preflight.sh
@@ -71,46 +71,12 @@ set_cfg() { # top sub value
   esac
 }
 
-trim_quotes() { # strip surrounding whitespace and matching quotes
-  local v=$1
-  v=${v#"${v%%[![:space:]]*}"} # ltrim
-  v=${v%"${v##*[![:space:]]}"} # rtrim
-  case "$v" in
-    \"*\") v=${v#\"}; v=${v%\"} ;;
-    \'*\') v=${v#\'}; v=${v%\'} ;;
-  esac
-  printf '%s' "$v"
-}
-
-parse_config() { # path -> 0 ok / 1 parse failure
-  local file=$1 in_fm=0 cur_top="" line
-  while IFS= read -r line || [ -n "$line" ]; do
-    line=${line%$'\r'} # tolerate CRLF configs (this file lives in the target repo)
-    if [ "$in_fm" = 0 ]; then
-      [ "$line" = "---" ] && in_fm=1
-      continue
-    fi
-    [ "$line" = "---" ] && return 0
-    case "$line" in '' | '#'*) continue ;; esac
-    if [[ "$line" =~ ^([A-Za-z_][A-Za-z0-9_]*):[[:space:]]*(.*)$ ]]; then
-      cur_top=${BASH_REMATCH[1]}
-      local val
-      val=$(trim_quotes "${BASH_REMATCH[2]}")
-      [ -n "$val" ] && set_cfg "$cur_top" "" "$val"
-    elif [[ "$line" =~ ^[[:space:]]+([A-Za-z_][A-Za-z0-9_]*):[[:space:]]*(.*)$ ]]; then
-      [ -n "$cur_top" ] || return 1
-      set_cfg "$cur_top" "${BASH_REMATCH[1]}" "$(trim_quotes "${BASH_REMATCH[2]}")"
-    else
-      return 1 # unrecognized frontmatter line
-    fi
-  done <"$file"
-  return 0
-}
+# trim_quotes + parse_frontmatter now live in lib/common.sh (shared with pin-config.sh).
 
 config_present=false
 if [ -f "$config_path" ]; then
   config_present=true
-  if ! parse_config "$config_path"; then
+  if ! parse_frontmatter "$config_path" set_cfg; then
     degrade config-parse-failed "preflight: could not parse $config_path - read it yourself"
   fi
 fi

--- a/plugins/issue-to-pr/scripts/sensitive-paths.sh
+++ b/plugins/issue-to-pr/scripts/sensitive-paths.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# sensitive-paths.sh - flag a changed-file list that touches security-sensitive
+# areas, so the SKILL adds a /security-review pass (spec sec 5.2 security overlay).
+# Reads one path per line on stdin (e.g. `git diff --name-only "$BASE"...HEAD`).
+#
+# Matching is case-insensitive on whole path SEGMENTS and the filename STEM (last
+# extension stripped), NOT raw substring - so auth/, db/migrations/001.sql and .env
+# trip, while authors.py, thesaurus.md and payment_ui_copy.md do not (design D2).
+#
+#   git diff --name-only "$BASE"...HEAD | sensitive-paths.sh [--json]
+#
+# Emits SENSITIVE=true|false and MATCHED=<comma-list of matching paths>.
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --json) enable_json; shift ;;
+    *) shift ;;
+  esac
+done
+
+# A whole path segment or filename stem that names a sensitive area.
+sensitive_word() {
+  case "$1" in
+    auth | authz | authn | authentication | authorization | oauth | jwt | iam | sso) return 0 ;;
+    crypto | cryptography | keys | kms | keystore) return 0 ;;
+    secret | secrets | credential | credentials | password | passwords | session | sessions) return 0 ;;
+    payment | payments | billing | checkout) return 0 ;;
+    migration | migrations) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# A filename that is sensitive by pattern (dotenv, sql, key material).
+sensitive_filename() {
+  case "$1" in
+    .env | .env.*) return 0 ;;
+    *.sql | *.pem | *.key | *.p12 | *.pfx) return 0 ;;
+    id_rsa | id_dsa | id_ecdsa | id_ed25519) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+matched=()
+while IFS= read -r path || [ -n "$path" ]; do
+  [ -n "$path" ] || continue
+  lc=$(printf '%s' "$path" | tr '[:upper:]' '[:lower:]')
+  hit=0
+  # Filename patterns.
+  fname=${lc##*/}
+  if sensitive_filename "$fname"; then hit=1; fi
+  # Whole-segment matches (each '/'-delimited segment, and the filename stem).
+  if [ "$hit" = 0 ]; then
+    stem=${fname%.*} # strip the last extension only
+    local_ifs=$IFS
+    IFS=/
+    for seg in $lc; do
+      [ -n "$seg" ] || continue
+      if sensitive_word "$seg"; then hit=1; break; fi
+    done
+    IFS=$local_ifs
+    if [ "$hit" = 0 ] && sensitive_word "$stem"; then hit=1; fi
+  fi
+  [ "$hit" = 1 ] && matched+=("$path")
+done
+
+if [ "${#matched[@]}" -gt 0 ]; then
+  emit SENSITIVE true
+  emit MATCHED "$(join_by , "${matched[@]}")"
+else
+  emit SENSITIVE false
+  emit MATCHED ""
+fi
+done_ok

--- a/plugins/issue-to-pr/scripts/stage-guard.sh
+++ b/plugins/issue-to-pr/scripts/stage-guard.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# stage-guard.sh - PreToolUse hook that enforces explicit-path staging (a hard
+# rule) the way merge-guard.sh enforces the merge gate. It DENIES `git add -A`,
+# `git add --all`, and `git add .`, which would sweep in local-only artifacts
+# (docs/superpowers, .serena, tmp/task-*). Everything else passes through to the
+# normal permission flow. Shares the hook helpers in lib/common.sh.
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+input=$(cat)
+# Fast path: only `git add` commands are guarded.
+case "$input" in
+  *"git add"*) : ;;
+  *) hook_passthrough ;;
+esac
+
+cmd=$(hook_extract_command "$input")
+cmd=$(printf '%s' "$cmd" | tr -s '[:space:]' ' ' | tr -d '\042\047')
+
+case "$cmd" in
+  *"git add"*" -A"* | *"git add"*" --all"* | *"git add"*" ." | *"git add"*" . "* | *"git add"*" :/"*)
+    hook_deny "git add -A / --all / . / :/ stages everything, including local-only artifacts (docs/superpowers, .serena, tmp/task-*). Stage explicit paths instead: git add path1 path2." ;;
+esac
+
+hook_passthrough

--- a/plugins/issue-to-pr/scripts/tier-select.sh
+++ b/plugins/issue-to-pr/scripts/tier-select.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# tier-select.sh - map triage-evidence.sh signals to a machinery tier (spec sec 5.2).
+# Reads triage-evidence.sh's KEY=VALUE block on stdin and emits TIER + TIER_REASON.
+# The rubric is a deterministic function so cost-scaling is CI-verifiable and cannot
+# silently drift (design D2). `--tier <t>` always overrides. Borderline picks higher.
+#
+#   triage-evidence.sh <N> | tier-select.sh [--tier trivial|standard|complex|epic] [--json]
+#
+# Tiers: trivial | standard | complex | epic. (Epic MODE - decompose - is v2.0; here
+# epic is just the detected tier and the SKILL treats it as complex+ for now.)
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+override=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --tier) override=${2:-}; shift 2 2>/dev/null || shift "$#" ;;
+    --json) enable_json; shift ;;
+    -*) warn "tier-select: ignoring unknown flag: $1"; shift ;;
+    *) shift ;;
+  esac
+done
+
+new_hits=0 checklist=0 ref_exist=0 body_len=0 labels=""
+while IFS= read -r line || [ -n "$line" ]; do
+  case "$line" in
+    NEW_THING_HITS=*) new_hits=${line#*=} ;;
+    CHECKLIST_ITEMS=*) checklist=${line#*=} ;;
+    REF_PATHS_EXIST=*) ref_exist=${line#*=} ;;
+    BODY_LENGTH=*) body_len=${line#*=} ;;
+    LABELS=*) labels=${line#*=} ;;
+  esac
+done
+
+# Coerce anything non-numeric to 0 so a malformed line can't crash the arithmetic.
+num() { case "$1" in '' | *[!0-9]*) printf '0' ;; *) printf '%s' "$1" ;; esac; }
+new_hits=$(num "$new_hits")
+checklist=$(num "$checklist")
+ref_exist=$(num "$ref_exist")
+body_len=$(num "$body_len")
+
+has_label() { # label -> 0 if present (case-insensitive, comma-list)
+  case ",$(printf '%s' "$labels" | tr '[:upper:]' '[:lower:]')," in
+    *",$1,"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+tier="" reason=""
+if [ -n "$override" ]; then
+  tier=$override
+  reason="--tier override"
+elif [ "$new_hits" -ge 3 ] && [ "$ref_exist" -eq 0 ]; then
+  tier=epic
+  reason="new-system signal (new-thing hits >=3, references no existing paths)"
+elif [ "$new_hits" -ge 1 ] || [ "$checklist" -ge 3 ] || [ "$ref_exist" -ge 3 ] \
+  || has_label design || has_label ux || has_label breaking; then
+  tier=complex
+  reason="design/new-behavior signal (new-thing hits, checklist, refs, or label)"
+elif [ "$new_hits" -eq 0 ] && [ "$ref_exist" -le 1 ] && [ "$checklist" -le 1 ] \
+  && [ "$body_len" -lt 400 ] && ! has_label feature && ! has_label design && ! has_label epic; then
+  tier=trivial
+  reason="minimal signal (no new-thing, <=1 ref, <=1 checklist, short body)"
+else
+  tier=standard
+  reason="default (known-code change)"
+fi
+
+emit TIER "$tier"
+emit TIER_REASON "$reason"
+done_ok

--- a/plugins/issue-to-pr/skills/issue-to-pr/SKILL.md
+++ b/plugins/issue-to-pr/skills/issue-to-pr/SKILL.md
@@ -2,285 +2,139 @@
 name: issue-to-pr
 description: >-
   Drive a GitHub issue — bare or tracked on a Project board — from triage to a
-  merge-ready PR through a gated pipeline (design cross-review, tests green,
-  code-review loop). Auto-links the issue to close on merge and advances the
-  board card's status as work progresses, then merges and cleans up once you
-  approve the PR in-session. Triggers: "take task N", "work on issue #N",
-  "do the next task", "start issue 7", and — for the merge gate on a follow-up
+  merge-ready PR through a gated pipeline (design hardening, tests green,
+  code-review clean), scaling the machinery to the task's tier and asking at most one
+  batched question. Auto-links the issue to close on merge, advances the board card,
+  then merges and cleans up once you approve the PR in-session. Triggers: "take task
+  N", "work on issue #N", "do the next task", and — for the merge gate on a later
   turn — "merge it", "approve the PR", "ship it", "lgtm merge".
 user-invocable: true
-argument-hint: "[issue-number | next]"
+argument-hint: "[issue-number | next | \"free text\"] [--tier trivial|standard|complex|epic]"
 ---
 
 # issue-to-pr — issue → merge-ready PR pipeline
 
-One repeatable flow for taking a single GitHub issue from triage and shipping it as a
-pull request. The shape is the same every time so nothing gets skipped. The **gates**
-(design cross-review, tests green, code-review clean) block forward progress. Create one
-todo per step.
-
-The input can be a **bare issue** or a **card on a GitHub Projects (v2) board** — the
-pipeline is identical. The PR always links the issue (`Closes #N`) so it auto-closes when the
-PR merges into the default branch; when the issue is tracked on a board, the card's status is
-advanced as work progresses (Step 0 decides which mode applies).
-
-This skill authorizes branching, committing, and opening a PR — all inside an isolated
-worktree so concurrent local runs never clash. It **merges only after you approve the PR in
-this session** (squash), then cleans up the branch, worktree, and temp artifacts. The squash
-writes to the base branch, so that merge is the one irreversible step — it happens on nothing
-less than an explicit, unambiguous go-ahead (Step 11), and even then never force-pushes or
-bypasses branch protection.
-
-## Configuration (optional)
-
-Per-project settings live in `.claude/issue-to-pr.local.md` (YAML frontmatter): the board
-URL, base branch, and the typecheck/test/visual commands. Everything is optional — with no
-file the skill auto-detects commands and runs by issue argument. `preflight.sh` (Step 0) parses
-this file and resolves the commands + base for you (`CMD_TEST`, `CMD_TYPECHECK`, `BASE`, ...).
-Schema: `${CLAUDE_PLUGIN_ROOT}/skills/issue-to-pr/references/configuration.md`. This guide refers
-to the resolved commands as `<typecheck_cmd>`, `<test_cmd>`, `<visual_cmd>`.
-
-**Resolve config in the main checkout, up front.** This file is gitignored, so it does not
-exist inside the worktree — read it (and the resolved commands + base) in `<original-root>`
-before entering the worktree, and carry the resolved values; never re-read config from inside
-the worktree, or the pinned commands are silently lost to auto-detect.
-
-## Companion skills (optional, graceful)
-
-The pipeline is sharper with a few companions but never breaks without them — it runs the
-inline equivalent and names what would have improved the result. Capability → preferred
-skill → fallback map: `${CLAUDE_PLUGIN_ROOT}/skills/issue-to-pr/references/companions.md`.
-Short form: `superpowers:brainstorming`/`writing-plans`/`test-driven-development`/
-`systematic-debugging`/`verification-before-completion`, `/deep-research`, `/cross-review`
-(from `codex-collaboration`), `humanizer`, and `/code-review` — used **if available**,
-otherwise the inline equivalent.
+One repeatable, gated flow: the **gates** (design hardening, tests green, review clean,
+approval-gated merge) block progress; the depth between them scales to the tier. Mechanics
+live in tested scripts (`S/` = `${CLAUDE_PLUGIN_ROOT}/scripts/`, `R/` = `references/`); you
+own judgment. One todo per step.
 
 ## Hard rules (never violate)
 
-- **New task = new branch, in its own worktree.** Determine the integration base FIRST (from
-  config `base_branch`; `auto` = `dev` if a `dev` branch exists locally or on the remote, else
-  `main`), then cut the branch from THAT same ref: `feat/issue-<N>-<slug>` or
-  `fix/issue-<N>-<slug>` (the issue number is baked in so the branch can't collide across
-  issues), inside a dedicated `../<repo>-worktrees/issue-<N>` worktree (see
-  `${CLAUDE_PLUGIN_ROOT}/skills/issue-to-pr/references/contracts.md`). All work
-  happens there; never run two tasks in the same working tree. The branch you start from and
-  the PR target must be the same base, or commits living only on `dev` go missing and surface
-  as conflicts at merge.
-- **Merge is gated on explicit in-session approval.** Open the PR and stop. Only merge
-  (squash) after the user approves *this* PR in the session — never on the same turn the PR
-  opens. After a successful merge, clean up (Step 12).
-- Stage with **explicit paths** (`git add path1 path2`). Never `git add -A` / `git add .`.
-- Human-facing text (UI strings >1–2 words, the report, the PR body) passes through
-  `humanizer` if installed. Code identifiers, dev comments, log lines, and
-  conventional-commit subjects do not.
-- Conventional Commits. TDD (failing test first) for any logic.
-- Don't ask the user a question you can answer yourself — see Step 3.
-- Don't claim "done / green / passing" without showing the command output
-  (`verification-before-completion`, or just paste the output).
+- **New task = new branch in its own worktree** (`S/worktree.sh ensure`), cut from the
+  resolved base. All work happens there; never two tasks in one tree.
+- **Merge is gated on explicit in-session approval**, runs ONLY in the main session
+  (plugin agents ignore the hook), via `S/approve.sh` + `S/worktree.sh merge` — never a
+  bare `gh pr merge`, never on the turn the PR opens.
+- **Ask contract:** contact the user at exactly three moments — (1) ONE batched
+  `AskUserQuestion` at Step 4.5 (only if the ledger has open items), (2) the merge gate,
+  (3) a hard stop. Decide everything else yourself and log it (see below).
+- Stage with **explicit paths** (`git add path1 path2`); never `git add -A`/`.` (a hook
+  denies it). Conventional Commits. TDD (failing test first) for any logic.
+- **Humanizer** runs on 100% of human-facing text (report, PR body, UI strings > 1–2 words)
+  regardless of tier — not code/logs/commit subjects. Don't claim "green/passing" without the
+  command output. Don't ask what a script or the code can answer.
 
-## Step 0 — Resolve the input + detect mode
+## Config, tier, ask contract, state
 
-Turn the request into a concrete issue and decide whether board-status sync applies. **Run
-`${CLAUDE_PLUGIN_ROOT}/scripts/preflight.sh <N>` first** (from the main checkout) — one call
-returns auth/scopes, repo owner/name, resolved `BASE`/`START_POINT`, auto-detected gate commands,
-issue state, `WORKTREE_STATE`, and `BOARD_CONFIGURED`/`BOARD_MEMBER`. Then apply the mode table.
-Script keys and exit codes: `${CLAUDE_PLUGIN_ROOT}/skills/issue-to-pr/references/contracts.md`.
+- **Config** (`.claude/issue-to-pr.local.md`, optional): `preflight.sh` parses it +
+  resolves gate commands and base (schema `R/configuration.md`); resolve in the main
+  checkout up front (gitignored, absent in the worktree). **Companions** (if installed,
+  else inline): `superpowers:*`, `/deep-research`, `/cross-review`, `humanizer`,
+  `/code-review` (`R/companions.md`).
+- **Tier** (`R/tier-matrix.md`): Step 2 pipes `triage-evidence.sh` into `tier-select.sh`
+  → `TIER`, routing research, design, review level/passes, security overlay, and report
+  length. `--tier` overrides.
+- **Autonomy** (`R/autonomy.md`, read once at Step 0): the ask contract (three contact
+  moments; log every judgment call to `state.json.ledger[]` before the next tool call;
+  auto-decisions rendered in the report + PR body), the `state.json` schema + append-only
+  `step.log` ground truth, and the resume path (log wins over stale state).
 
-| Input | Mode |
-|---|---|
-| `#N` / issue URL, no board configured | **issue-mode** — link `Closes #N` only |
-| `#N`, and the issue is on the configured board | **board-mode** — link + advance the card |
-| `next` / top card of `board.url` | **board-mode** |
-| board card with no backing issue (draft) | convert draft → issue, then proceed |
+## Steps
 
-- Derive the repo owner from `gh repo view --json owner,name`.
-- Detect board membership: query the issue's `projectItems`. Empty (and no board arg) →
-  issue-mode. Otherwise board-mode for the project in `board.url` (or the first, with a
-  note).
-- Board-mode needs the `project` token scope. If it's missing, **do not fail** — run
-  link-only and tell the user `gh auth refresh -s project`.
+**0. Resolve + preflight.** Turn the request into an issue (free text → draft one if scope is
+clear; a draft board card → convert it to an issue first; `next` → the board's top card).
+`S/preflight.sh <N> [--claim]` → auth/scopes, repo, `BASE`/`START_POINT`, gate
+cmds, issue state, `WORKTREE_STATE`, board membership. **`WARN_CLAIMED_BY` → hard stop and
+ask before any further work** (never run an opus design on someone else's issue).
+`gh-auth-failed` (2) / config parse (4) → stop. Write the initial state.json.
 
-## Step 1 — Read the task + context
+**1. Worktree.** `S/worktree.sh ensure <N> --branch feat|fix/issue-<N>-<slug> --start-point
+<START_POINT>`; `cd WT_PATH`, install deps via `INSTALL_HINT` through `run-gates.sh`.
+Exit-code dispatch (bad-checkout, stale dir, invalid start-point, exit-3 in-place fallback):
+`R/contracts.md`. Board-mode: `S/board-sync.sh <owner/repo> <N> in_progress` in the
+background (add `--option "$STATUS_MAP_IN_PROGRESS"` if preflight reported one).
 
-- `gh issue view <N>` for the issue. Skim siblings (`gh issue list --state all`) so the
-  change fits the roadmap.
-- Open the files the issue points at; map the real code (functions, wiring, existing tests,
-  any visual harness).
-- Confirm the base branch (Hard rules + `git branch -a`).
-- **Cut the branch inside an isolated worktree** with `${CLAUDE_PLUGIN_ROOT}/scripts/worktree.sh
-  ensure <N> --branch <branch> --start-point <START_POINT>` (from the main checkout). It
-  creates / resumes / reattaches and reports `WT_PATH`, `STATE`, and `INSTALL_HINT`. `cd` into
-  `WT_PATH`, then **install dependencies** — a fresh worktree has only tracked files (no
-  `node_modules`/`.venv`/etc), so run `INSTALL_HINT` through `run-gates.sh` (keeps output out of
-  context) before touching any file. Exit-code handling (bad-checkout, stale dir, invalid
-  start-point, permission → in-place fallback) is in
-  `${CLAUDE_PLUGIN_ROOT}/skills/issue-to-pr/references/contracts.md` → "worktree.sh". Everything
-  downstream runs there.
-- **Board-mode:** once work begins, `${CLAUDE_PLUGIN_ROOT}/scripts/board-sync.sh <owner/repo> <N>
-  in_progress` (run it in the background; it always exits 0 and never blocks progress). If
-  preflight reported `STATUS_MAP_IN_PROGRESS`, append `--option "<that value>"`.
+**2. Triage.** `S/triage-evidence.sh <N> | S/tier-select.sh [--tier …]` → `TIER`; record it.
 
-## Step 2 — Triage complexity (decides the path)
+**3. Research** (tier routes it, complex+ with unknowns): the forked `research` sub-skill (or
+`/deep-research`) returns a ≤150-line cited summary; raw exploration stays out of context.
 
-Run `${CLAUDE_PLUGIN_ROOT}/scripts/triage-evidence.sh <N>` for objective signals (labels,
-checklist items, referenced-paths-that-exist, new-thing keywords, linked issues), then map them
-to a level yourself:
+**4. Design** (tier routes it). Complex+: `Workflow({scriptPath:
+"S/../workflows/design-panel.js", args:{issue,title,contextFiles,constraints,openQuestions}})`
+→ `design_md` (→ `tmp/task-<N>/design.md`) + rejected alternatives + open questions. Accept
+only if `design_md` non-empty and `rejected_alternatives.length >= 1`, else inline
+self-review; `/cross-review` critiques the result. Preference-bound questions → ledger.
+Standard: a mini-design in the PR body.
 
-- **Simple** (one obvious edit, no design choices): skip to Step 5, implement directly with
-  TDD.
-- **Complex** (real design/UX choices, multiple files, new behavior): brainstorm (Step 3+).
-- **Very complex** (unfamiliar domain, external systems, security/perf unknowns): gather
-  context first (`/deep-research` if available, else a focused web-search pass), then
-  brainstorm.
+**4.5. Checkpoint (unconditional slot).** If the ledger has open `asked` items, ask them in
+ONE batched `AskUserQuestion`. Empty ledger → no-op. The only mid-run question.
 
-When in doubt, treat it as one level harder.
+**5. Plan + implement.** Turn the design into a plan (`superpowers:writing-plans` for
+complex+); TDD: failing test → implement → passing. UI/layout work is verified with
+`<visual_cmd>` or a browser test, never eyeballing.
 
-## Step 2.5 — Decide on state tracking
+**6. Gates.** `S/run-gates.sh --log-dir tmp/task-<N>/logs --gate typecheck='<typecheck_cmd>'
+--gate test='<test_cmd>'` (+ `--gate visual=…` for UI). An empty gate command degrades
+(exit 4), never a false green. Red ⇒ STOP and fix. Never proceed red.
 
-- If the task is complex+ and will likely outlive a context compaction, keep a short progress
-  file at **`tmp/task-<N>/progress.md` inside the worktree** (gitignored): branch,
-  `<original-root>`, decisions, plan checklist, current step.
-- Put the **design doc there too** (`tmp/task-<N>/design.md`) unless your project commits design
-  docs under `docs/`. Treat it as a working artifact.
-- Keep these *inside* the worktree so a resume restores them and Step 12 removes them for free
-  when the worktree is torn down. Write with an absolute path (or `cd` into the worktree first) —
-  don't assume a bare relative path lands there. Only in the sandbox-fallback (in-place) case is
-  there no worktree; then use the session scratchpad, and Step 12 sweeps it explicitly (see its
-  keep-list).
+**7. Review loop.** `/code-review <level> --fix` at the tier's level, ≤ tier's max passes.
+**Security overlay:** `git diff --name-only "$BASE"...HEAD | S/sensitive-paths.sh`; `SENSITIVE=true`
+→ +1 `/security-review`. Track `confirmed_bugs_this_pass`/`gate_fail_streak` in metrics; **escalate a level** on 2+ confirmed bugs/pass or a gate failing twice; re-run gates after each fix.
 
-## Step 3 — Brainstorm (complex+ only)
+**8. Re-gates + pin config.** Re-run `run-gates.sh` (all green). If auto-detected cmds passed
+and config lacks them, `S/pin-config.sh --config <ORIGINAL_ROOT>/.claude/issue-to-pr.local.md
+--test '…' …` (the main checkout — NOT the worktree, which Step 12 deletes); note in the report.
 
-Use `superpowers:brainstorming` if installed; otherwise run the same loop inline. Before
-asking the user anything:
-1. Investigate the code + existing issues; form the best answer yourself.
-2. Still unsure? Use web search / docs lookup to settle it.
-3. Only a genuine, still-open judgment call after that goes to the user. Auto-decide
-   everything you reasonably can.
+**9. Commit + PR.** `git add <explicit paths>`, conventional subjects; `git push -u origin
+<branch>`; `gh pr create` against `BASE`, `Closes #<N>`, humanized body (autonomous-decisions
+section + rejected alternatives). Board-mode: `S/board-sync.sh <owner/repo> <N> in_review`.
+**Stop** — merging is Step 11.
 
-When writing the design doc, **plan the tests explicitly**. Anything that needs external or
-visual inspection (UI, layout, browser behavior) must be verifiable with `<visual_cmd>` or
-a dedicated browser test — not eyeballing alone. Logic gets unit/integration tests.
-
-## Step 4 — Harden the design (GATE)
-
-- Self-review the design doc.
-- Run `/cross-review` on it for cross-agent critique (needs `codex-collaboration` + Codex
-  authenticated, `/codex:setup`). If unavailable and you can't fix it yourself, **don't
-  stall** — run an equivalent multi-agent review via `Workflow` (several independent
-  reviewers with distinct lenses → adversarial synthesis). Resolve every finding — accept,
-  reject (with reason), or fix.
-- Gate: the doc meets a high bar (clear problem, chosen approach with rejected
-  alternatives, explicit test plan, risks) before any code. Bugs caught here are far cheaper
-  than after implementation.
-
-## Step 5 — Plan + implement
-
-- Turn the design into a written plan (`superpowers:writing-plans` if available), then
-  execute.
-- **Execution mode:** if the work parallelizes and you're in a multi-agent mode, run it
-  through a `Workflow` (fan-out + adversarial verify). Otherwise use
-  `superpowers:subagent-driven-development`, or just implement directly with TDD for a
-  single tightly-coupled file.
-- Write the test first, watch it fail, implement, watch it pass.
-
-## Step 6 — Tests green (GATE)
-
-- Run `${CLAUDE_PLUGIN_ROOT}/scripts/run-gates.sh --log-dir tmp/task-<N>/logs --gate
-  typecheck='<typecheck_cmd>' --gate test='<test_cmd>'` (add `--gate visual='<visual_cmd>'` for
-  UI). The printed `GATES_OK=true` + `GATE_*_EXIT` block is the green proof; a failing gate
-  surfaces only its last 40 lines.
-- Anything red ⇒ STOP and fix (`superpowers:systematic-debugging` or a disciplined inline
-  pass). Never proceed red.
-
-## Step 7 — Code review loop (GATE)
-
-- Run `/code-review` (e.g. `max --fix` if your setup supports it). Apply real findings;
-  record skipped ones (false positives / out-of-scope) with a one-line reason.
-- **Each pass reviews the updated diff** — your own fixes can introduce new regressions
-  (normal; expect ~1 real follow-up per pass for a while). Re-run typecheck + tests (+ visual
-  for UI) after every fix pass, and feed the next pass a summary of what changed.
-- Repeat until a pass yields no actionable findings, or 5 passes total — whichever comes
-  first. Say how many passes ran and what converged.
-
-## Step 8 — Re-run all tests
-
-- Re-run the same `run-gates.sh` invocation (typecheck + test, + visual for UI) once more after
-  the review edits. All green before the PR.
-
-## Step 9 — Commit + PR
-
-- `git add <explicit paths>`, conventional-commit subjects (separate unrelated concerns).
-- Push the branch **with upstream tracking** — `git push -u origin <branch>` (Step 11's merge
-  precondition relies on it). Open a PR against the base from Step 1 with `gh pr create`. Link the
-  issue (`Closes #<N>`) so it auto-closes when the PR merges into the default branch. PR body is
-  human-facing → humanize it.
-- **Board-mode:** `${CLAUDE_PLUGIN_ROOT}/scripts/board-sync.sh <owner/repo> <N> in_review`
-  (background, best-effort). `Done` is left to merge-time — GitHub's automation moves the card
-  when the issue closes (on a default-branch merge).
-- The PR opens here and the skill **stops**. Merging is Step 11, gated on the user's approval
-  — do **not** merge or deploy on this turn.
-
-## Step 10 — Report (plain language)
-
-Short, human, no jargon — understandable by a 3rd-year student:
-- What was built and why, how it works, what was tricky, what was decided.
-- Test status (with the green proof) and anything the user must do by hand (manual setup,
-  secrets, follow-up).
-- The PR link.
-- End with a clear hand-back: the PR is up and waiting — ask the user to reply when they want
-  it merged. Then **stop**; the skill's turn ends here.
+**10. Report.** Length per tier (3 lines → full). What was built and why, test status with the
+green proof, the autonomous decisions, the PR link, and the `metrics` telemetry (gate runs,
+review passes/level, which machinery fired). Hand back: ask when to merge, and **stop**.
 
 ## Step 11 — Merge on approval (GATE)
 
-On a later turn your CWD may have reset to the main checkout, so **return to your working tree
-first**: in worktree mode `cd` into `../<repo>-worktrees/issue-<N>`; in the sandbox in-place
-fallback there's no worktree, so stay in the main checkout on `<branch>` (contracts.md →
-"worktree.sh" covers both). Then read the user's reply against *this* PR. **Merge only on an unambiguous go-ahead to merge THIS PR — the burden is on a
-clear approval. If the reply is anything else, do not merge.**
-- **Go-ahead** — an unmistakable instruction to merge this PR ("merge it", "lgtm, ship it",
-  "approved", "go ahead and merge") → run `${CLAUDE_PLUGIN_ROOT}/scripts/approve.sh <branch>
-  --quote "<verbatim reply>"`, then `${CLAUDE_PLUGIN_ROOT}/scripts/worktree.sh merge <N> --branch
-  <branch>`. That script is the only sanctioned merge path; the PreToolUse hook and the script
-  both validate the single-use approval marker before `gh pr merge` runs.
-- **Change requests** → treat as review feedback: implement in the worktree, then **re-run the
-  gates** — Step 6 (typecheck + tests, + visual for UI) and Step 7 (code-review) on the new diff,
-  fixing until clean — before pushing to the same branch, re-reporting, and waiting for approval
-  again. A change-request edit must clear the same gates as the original work; never merge
-  unverified changes.
-- **Anything else** → do **not** merge. If the reply is a vague acknowledgment ("ok", "cool",
-  "looks fine") or a question about the PR, ask them to confirm the merge explicitly. If the user
-  will merge it themselves later or has abandoned the task, ask whether to tear down the local
-  worktree now — via the **"Teardown without merging"** section, which removes only the local
-  worktree and **keeps the PR and its remote branch intact** (never the section-3 cleanup, which
-  deletes the remote branch and would close the open PR). Don't silently leave a stale worktree a
-  later run would resume from. There is no timeout; approval is purely explicit — never inferred.
-
-Merge mechanics and failure handling (marker validation, `git push` precondition, squash by head
-branch, the single retry for pending checks, when to stop):
-`${CLAUDE_PLUGIN_ROOT}/skills/issue-to-pr/references/contracts.md` → "worktree.sh". If `merge`
-exits 2 (`STOP_REASON=`), **skip cleanup** — the worktree and branch stay put so nothing is lost.
+Return to your working tree first: `cd` into `../<repo>-worktrees/issue-<N>` (worktree
+mode); in the in-place fallback stay in the main checkout on `<branch>`. Then read the reply
+against *this* PR. **Merge only on an unambiguous go-ahead to merge THIS PR — the burden is
+on a clear approval. If the reply is anything else, do not merge.**
+- **Go-ahead** ("merge it", "lgtm, ship it", "approved", "go ahead and merge") → `S/approve.sh
+  <branch> --quote "<verbatim reply>"`, then `S/worktree.sh merge <N> --branch <branch>`. That
+  script is the only sanctioned merge path; the hook + the script both validate the single-use
+  marker before `gh pr merge` runs. If `merge` exits 2 (`STOP_REASON=`), **skip cleanup**.
+- **Change requests** → implement in the worktree, **re-run the tier gates** (Steps 6–7 on the
+  new diff) until clean, push, re-report, wait again. Never merge unverified changes.
+- **Anything else** → do **not** merge. A vague ack ("ok", "looks fine") or a question → ask for
+  explicit confirmation. If they'll self-merge/abandon, offer `S/worktree.sh teardown <N>` (keeps
+  the PR + remote branch; never `cleanup`, which deletes them). Approval is never inferred.
 
 ## Step 12 — Cleanup (after a successful merge)
 
-Only after Step 11 merges. First confirm the outcome honestly: GitHub auto-closes the linked
-issue (and moves the board card to Done) **only on a merge into the default branch** — if the
-base was a non-default branch like `dev`, the issue stays open on purpose; say so rather than
-reporting it closed (see the reference's "Merge on approval" outcome check). Then clean up: order
-matters — you can't remove a worktree from inside it. **`cd` your shell into `<original-root>`
-first** (not just the subprocess — a shell whose current directory is the worktree locks it on
-Windows and the removal fails). **Salvage any lasting design doc first**
-(`git worktree remove` silently deletes gitignored files), then, from the main checkout, run
-`${CLAUDE_PLUGIN_ROOT}/scripts/worktree.sh cleanup <N> --branch <branch> --salvage-to <dir>` (it
-salvages design/progress/state, removes the worktree, deletes the merged local + remote branch,
-and refuses on tracked dirtiness `STOP_REASON=dirty-tracked-files`). Report from its keys, not from
-assumption — if `DELETED_LOCAL=false` or it emits `LEFTOVER_DIR`, a locked directory remains; say so
-and remove it by hand once the lock clears. Then sweep temp artifacts outside
-the worktree — honoring the keep-list (committed `docs/`, anything already in the PR, anything the
-user asked to keep). Keys, the in-place variant, and the teardown (self-merge/abandon) path:
-`${CLAUDE_PLUGIN_ROOT}/skills/issue-to-pr/references/contracts.md` → "worktree.sh".
-Finish with one line naming what was merged, what was removed, and anything kept.
+Only after Step 11 merges. Confirm honestly: GitHub closes the issue / advances the card
+**only on a merge into the default branch** — on a non-default base the issue stays open, so
+say so. **`cd` your shell into the main checkout first** (a shell whose cwd is the worktree
+locks it on Windows). Salvage any lasting design doc, then `S/worktree.sh cleanup <N> --branch
+<branch> --salvage-to <dir>` (removes the worktree, deletes the merged local + remote branch +
+marker). Report from its keys — `DELETED_LOCAL=false` or a `LEFTOVER_DIR` means a locked dir
+remains; say so, remove it by hand once the lock clears. In-place fallback (no worktree):
+switch off `<branch>`, delete it local+remote, sweep the scratchpad temp (keep committed
+`docs/`, PR content, anything you were asked to keep). Details: `R/contracts.md` →
+"worktree.sh". Finish with one line: what merged, what was removed, what was kept.
 
-## Step 13 — Improve this skill
+## Friction log (replaces the old improve-this-skill step)
 
-After shipping, reflect: did any step bite, stay unclear, or get skipped? If so, refine this
-SKILL.md. Leave it sharper than you found it.
+When a step genuinely fought back, append one dated one-line note to
+`.claude/issue-to-pr/friction.log`; `/issue-to-pr:tune` batches it into fixes later (mention it in the report only above 10 lines).

--- a/plugins/issue-to-pr/skills/issue-to-pr/references/autonomy.md
+++ b/plugins/issue-to-pr/skills/issue-to-pr/references/autonomy.md
@@ -1,0 +1,63 @@
+# Autonomy — ask contract, ledger, and state (spec sec 5.1 + 5.5)
+
+The pipeline decides what it reasonably can on its own, records every decision, and
+surfaces the automatic ones where the human already looks (the report and the PR body).
+
+## Ask contract — three moments only
+
+Contact the user at exactly three points:
+1. **Step 4.5 checkpoint** — ONE batched `AskUserQuestion`, only if the ledger has open
+   `asked` items. This is the single mid-run question.
+2. **The merge gate** (Step 11) — always.
+3. **A hard stop** — an exit-2 with no safe default (e.g. `WARN_CLAIMED_BY`, a
+   gate-critical unknown).
+
+A question is for the user (`kind: asked`) only when it is:
+- **preference-bound** — public API naming, user-visible UX/copy, paid/external
+  resources, a new external dependency or license, or a breaking API/schema change; or
+- **gate-critical unresolvable** — no test command is detectable, so the gates cannot run.
+
+Everything else is decided autonomously (`kind: auto`) and logged. Forbidden: proceeding
+past the checkpoint with a gate-critical unknown; asking mid-implementation anything that
+fits moment (1).
+
+## Ledger
+
+`state.json.ledger[]`, each `{question, decision, rationale, kind: asked|auto}`, appended
+**immediately, before the next tool call** (so a compaction can't lose a decision). Render
+the `auto` entries as a **"Decisions made autonomously"** section in the Step 10 report AND
+the PR body — the human reviews them at the merge gate they already attend. A Step 10 canary
+cross-checks the ledger entry count against the visible autonomous work.
+
+## state.json (schema v1) + step.log
+
+`tmp/task-<N>/state.json` (model-owned; the model reads/writes it as JSON) plus an
+append-only `tmp/task-<N>/step.log` that every side-effecting script writes one flat
+`KEY=VALUE` line to — the script-authored ground truth that survives a crash between a
+side effect and the model's state write.
+
+```json
+{ "schema_version": 1, "issue": 7, "tier": "standard", "branch": "…", "wt_path": "…",
+  "original_root": "…", "base": "dev", "start_point": "origin/dev",
+  "cmds": {"typecheck": "…", "test": "…", "visual": null, "smoke": null},
+  "board": {"project_id": "…", "item_id": "…", "field_id": "…", "options": {…}},
+  "steps": {"preflight": {"done": true, "at": "…"}, "…": {}},
+  "ledger": [{"question": "…", "decision": "…", "rationale": "…", "kind": "auto"}],
+  "metrics": {"gate_runs": 3, "gate_fail_streak": {}, "confirmed_bugs_this_pass": 0,
+    "review_passes": 2, "review_level": "medium", "design_panel_ran": false,
+    "research_fork_invocations": 0, "review_fallback_used": "design-panel",
+    "board_lookup_calls": 0, "started_at": "…"} }
+```
+
+- `tier` is written after Step 2 (null/pending before that).
+- **metrics** is the telemetry the Step 10 report prints so the owner can confirm the tier
+  scaled the work (which machinery fired, review level/passes, a rough spend proxy).
+
+## Resume after compaction
+
+Read `state.json`. If it is absent OR does not parse, treat it as absent and fall back to
+re-running preflight + reading `progress.md` + `step.log`. Otherwise cross-check each
+`steps.<name>.done` against a matching `step.log` line — **the log wins on a mismatch** —
+re-verify cheap outcomes (PR state via `gh pr view`), and jump to the first incomplete step.
+Anchor every `Edit` against state.json on the step name (or another unique key); prefer a
+whole-file `Write` when uniqueness is uncertain (the schema has repeated `{done,at}` fragments).

--- a/plugins/issue-to-pr/skills/issue-to-pr/references/companions.md
+++ b/plugins/issue-to-pr/skills/issue-to-pr/references/companions.md
@@ -11,8 +11,8 @@ companion silently degrade quality without saying so.
 | Test-first discipline (Step 5–6) | `superpowers:test-driven-development` | Write the failing test, watch it fail, implement, watch it pass. |
 | Debugging red tests (Step 6) | `superpowers:systematic-debugging` | Reproduce, isolate, hypothesize, fix one cause at a time; re-run. |
 | Done-claims (throughout) | `superpowers:verification-before-completion` | Never claim green without pasting the command output. |
-| Context gathering (Step 2, very complex) | `/deep-research` | A focused web-search + source-read pass. |
-| Design gate critique (Step 4) | `/cross-review` (from `codex-collaboration`) | A multi-agent `Workflow`: several independent reviewers with distinct lenses → adversarial synthesis. |
+| Codebase research (Step 3, complex+) | forked `research` sub-skill (isolated subagent → ≤150-line cited summary); `/deep-research` for external topics | A focused inline exploration distilled to a short summary. |
+| Design generation (Step 4, complex+) | `workflows/design-panel.js` (3 proposers → 2 adversarial critics → opus judge), with `/cross-review` critiquing the produced `design_md` | Inline self-review chain: draft, adversarially self-critique against the code, revise. |
 | Humanizing human-facing text (Step 9–10) | `humanizer` | Self-edit the PR body / report to drop AI-tell phrasing; flag that a humanizer pass would help. |
 | Diff review loop (Step 7) | `/code-review` | A manual diff read for correctness, reuse, and regressions; iterate. |
 

--- a/plugins/issue-to-pr/skills/issue-to-pr/references/contracts.md
+++ b/plugins/issue-to-pr/skills/issue-to-pr/references/contracts.md
@@ -106,3 +106,28 @@ left to GitHub's automation on the default-branch merge.
 `triage-evidence.sh <N> [--json]` — Step 2. Emits `LABELS BODY_LENGTH CHECKLIST_ITEMS
 REF_PATHS_EXIST REF_PATHS_MISSING NEW_THING_HITS LINKED_ISSUES TITLE` from the issue. You map the
 signals to a tier yourself. Exit `4` if the issue cannot be read.
+
+## tier-select.sh - map triage signals to a tier (v1.3.0)
+
+`triage-evidence.sh <N> | tier-select.sh [--tier trivial|standard|complex|epic] [--json]`
+Emits `TIER` + `TIER_REASON`. Deterministic rubric (full table + boundaries in
+`tier-matrix.md`); `--tier` overrides; borderline picks higher. Always exit 0.
+
+## sensitive-paths.sh - security overlay trigger (v1.3.0)
+
+`git diff --name-only "$BASE"...HEAD | sensitive-paths.sh [--json]` -> `SENSITIVE=true|false`
++ `MATCHED=`. Segment/stem-exact matching (auth, crypto, secrets, payment, migrations, plus
+`.env*`/`*.sql`/key material), so `authors.py` / `payment_ui_copy.md` do not false-trip.
+`SENSITIVE=true` -> add one `/security-review` pass. Always exit 0.
+
+## pin-config.sh - self-writing config (v1.3.0)
+
+`pin-config.sh --config <path> [--test <cmd>] [--typecheck <cmd>] [--visual <cmd>] [--smoke <cmd>]`
+Appends a gate command to the config's frontmatter only if unset (checked with preflight's
+shared parser, so a nested `commands:` value counts as set - NEVER overwrites a human value).
+Emits `PINNED=<keys>`. Exit 0; 4 if an existing config cannot be parsed (never corrupts it).
+
+## stage-guard.sh - explicit-path staging hook (v1.3.0)
+
+PreToolUse hook (in `hooks/hooks.json`, alongside merge-guard): denies `git add -A` / `--all`
+/ `.` and passes everything else through, so staging stays explicit. You never call it directly.

--- a/plugins/issue-to-pr/skills/issue-to-pr/references/tier-matrix.md
+++ b/plugins/issue-to-pr/skills/issue-to-pr/references/tier-matrix.md
@@ -1,0 +1,53 @@
+# Tier matrix — scale the machinery to the task (spec sec 5.2)
+
+The pipeline runs the same gates every time, but the *depth* between them scales to
+a tier. `scripts/tier-select.sh` computes the tier deterministically from
+`triage-evidence.sh` signals (so it is CI-tested and cannot silently drift); the
+SKILL reads `TIER` and routes each step accordingly.
+
+## Machinery per tier
+
+| Machinery | trivial | standard | complex | epic |
+|---|---|---|---|---|
+| Examples | typo, copy change, config value | bugfix, small feature in known code | new behavior / multi-file / design choices | new service or product, "from scratch" |
+| Session effort | suggest `low` | default | `high` | `high` |
+| Research (`skills/research`) | - | - | if unknowns | per child |
+| Design | - | mini-design in the PR body | **design-panel** or `/cross-review` | decompose first (v2.0) |
+| Plan | - | inline checklist | writing-plans | per child |
+| Tests / gates | always | always | always | per child |
+| `/code-review` | `low --fix`, 1 pass | `medium --fix`, <=2 passes | `high --fix`, <=3 passes (may raise to `max` on escalation) | per child + `ultra` on integrator PRs |
+| Security overlay | if sensitive paths | if sensitive paths | if sensitive paths | mandatory sweep |
+| Report | 3 lines | short | full | dashboard |
+
+## Rubric — signals to tier (implemented in `tier-select.sh`)
+
+Fed `triage-evidence.sh` output on stdin; `--tier <t>` always overrides; borderline
+picks the **higher** tier. Checked strongest-first:
+
+- **epic:** `NEW_THING_HITS >= 3` AND `REF_PATHS_EXIST = 0` (a new system referencing
+  no existing code). Epic *mode* (decompose into child issues) lands in v2.0; until
+  then the SKILL treats epic as complex and notes that decomposition is deferred.
+- **complex:** `NEW_THING_HITS >= 1` OR `CHECKLIST_ITEMS >= 3` OR `REF_PATHS_EXIST >= 3`
+  OR a `design` / `ux` / `breaking` label.
+- **trivial:** `NEW_THING_HITS = 0` AND `REF_PATHS_EXIST <= 1` AND `CHECKLIST_ITEMS <= 1`
+  AND `BODY_LENGTH < 400` AND no `feature` / `design` / `epic` label.
+- **standard:** everything else (a known-code change).
+
+Every tier: the test plan for anything UI/layout/browser must be verifiable with the
+project's `visual_cmd` or a dedicated browser test — never eyeballing alone.
+
+## Security overlay
+
+Regardless of tier, run `git diff --name-only "$BASE"...HEAD | sensitive-paths.sh`;
+if `SENSITIVE=true`, add one `/security-review` pass. Sensitive = a path segment or
+filename stem naming auth/authz, crypto/keys, secrets/credentials/sessions,
+payment/billing, or migrations, plus `.env*`, `*.sql`, and key material. Matching is
+segment/stem-exact, so `authors.py` and `payment_ui_copy.md` do not false-trip.
+
+## Escalation ratchet (one-way)
+
+Track in `state.json.metrics`: `confirmed_bugs_this_pass` (count of `/code-review`
+CONFIRMED verdicts) and `gate_fail_streak.<gate>`. When **2+ confirmed bugs land in
+one review pass**, or **the same gate fails twice**, escalate the review level one
+notch (never down); trivial->standard also re-enters the design step. Surface the raw
+per-pass counts in the Step 10 report so a missed ratchet is visible at the merge gate.

--- a/plugins/issue-to-pr/skills/research/SKILL.md
+++ b/plugins/issue-to-pr/skills/research/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: research
+description: >-
+  Internal forked research sub-skill for issue-to-pr. Runs raw codebase exploration
+  in an isolated subagent and returns a short, cited summary, so the main pipeline's
+  context is never flooded with file dumps. Not for direct use.
+when_to_use: Called by the issue-to-pr pipeline for complex+ tasks with unknowns.
+context: fork
+agent: Explore
+model: sonnet
+effort: medium
+disable-model-invocation: true
+user-invocable: false
+---
+
+# research — forked codebase exploration for issue-to-pr
+
+You are a research fork for the issue-to-pr pipeline. You run in an isolated
+subagent: **you see none of the caller's chat history** — only the prompt you were
+handed. Everything you need must be in that prompt. Your entire job is to answer a
+fixed set of questions about this codebase and return a compact, cited summary. The
+raw exploration (file reads, greps) stays in your context and never reaches the
+caller; only your summary returns.
+
+## Input (the caller inlines all of it)
+
+- the issue number and title,
+- an explicit **question list** — the specific unknowns to resolve,
+- any paths/areas the issue points at.
+
+If the prompt lacks a question list, answer the single implicit question "what does a
+change for this issue need to touch, and what are the risks?" and say you inferred it.
+
+## How to work
+
+1. Map the relevant code: find the functions, wiring, existing tests, and any
+   patterns a change would follow. Use Grep/Glob/Read; read excerpts, not whole trees.
+2. Answer each question directly. Prefer concrete `file:line` evidence over prose.
+3. Note confidence per answer (high / medium / low) and flag anything you could not
+   determine — an honest "unknown" is more useful than a guess.
+
+## Output contract (this is all the caller gets)
+
+A summary of **at most 150 lines**:
+
+- One short paragraph: what a change for this issue touches.
+- Per question: the answer, with `path:line` references, and a confidence note.
+- A short "risks / unknowns" list.
+
+Do not include raw file dumps, your search transcript, or step-by-step narration.
+Keep it tight — the caller pays for every line. If you would exceed 150 lines, cut
+the least-load-bearing detail and say what you trimmed.

--- a/plugins/issue-to-pr/skills/tune/SKILL.md
+++ b/plugins/issue-to-pr/skills/tune/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: tune
+description: >-
+  Process the issue-to-pr friction log into concrete skill/script improvements.
+  Reads .claude/issue-to-pr/friction.log, proposes batched edits with evidence, and
+  applies them on your approval. Run it when the log has built up.
+when_to_use: When the user runs /issue-to-pr:tune, or the friction log exceeds ~10 lines.
+argument-hint: "[--dry-run]"
+user-invocable: true
+disable-model-invocation: true
+---
+
+# tune — turn friction into fixes
+
+The issue-to-pr pipeline no longer has an always-on "improve this skill" step. Instead
+each run appends one line to `.claude/issue-to-pr/friction.log` (repo-local,
+gitignored) whenever a step genuinely fought back — a stop that should not have
+happened, an unclear instruction, a missed detection, a script that surprised the
+model. This skill batches that evidence into real changes.
+
+## Steps
+
+1. **Read the log.** `.claude/issue-to-pr/friction.log` (from the repo root). Each
+   line is a dated, one-sentence friction note with the step it hit. If the file is
+   absent or empty, say so and stop — nothing to tune.
+2. **Cluster.** Group the lines by root cause, not by surface symptom. Three notes
+   about the same confusing exit code are one fix, not three.
+3. **Propose.** For each cluster, propose the smallest concrete change to the SKILL,
+   a script, or a reference — quoting the friction lines as evidence. A change with
+   no evidence line does not belong here. Prefer edits that make a stop mechanical
+   (an exit code / a test) over prose that asks the model to remember.
+4. **Confirm, then apply.** Show the batched proposal and ask for a go-ahead. On
+   approval, make the edits (bump the plugin version + changelog per repo rules),
+   run the gates (`tests/run-tests.sh`), and — if the changed area is behavioral —
+   note that a fresh dogfood run should confirm it. With `--dry-run`, stop after the
+   proposal.
+5. **Prune.** After applying, remove the addressed lines from the friction log (keep
+   any not yet acted on) so the log reflects only open friction.
+
+Never apply blind: every edit traces to a friction line, and the human approves the
+batch. This keeps the skill improving from real use, not speculation.

--- a/plugins/issue-to-pr/tests/contract/test_pin-config.sh
+++ b/plugins/issue-to-pr/tests/contract/test_pin-config.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Contract tests for scripts/pin-config.sh (design D6, spec sec 5.6).
+
+test_pin_missing_config_degrades() {
+  run_script pin-config.sh --test "npm test"
+  assert_rc 4
+  assert_key "$OUT" DEGRADED_REASON missing-config
+}
+
+test_pin_creates_frontmatter() {
+  local cfg="$TEST_TMPDIR/cfg.md"
+  run_script pin-config.sh --config "$cfg" --test "npm test" --typecheck "tsc --noEmit"
+  assert_rc 0
+  assert_key "$OUT" PINNED "test,typecheck"
+  local c; c=$(cat "$cfg")
+  assert_contains "$c" "test_cmd: npm test"
+  assert_contains "$c" "typecheck_cmd: tsc --noEmit"
+}
+
+test_pin_idempotent_toplevel_never_overwrites() {
+  local cfg="$TEST_TMPDIR/cfg.md"
+  printf -- '---\ntest_cmd: my own test\n---\nnotes\n' >"$cfg"
+  run_script pin-config.sh --config "$cfg" --test "npm test"
+  assert_rc 0
+  assert_key "$OUT" PINNED ""
+  local c; c=$(cat "$cfg")
+  assert_contains "$c" "my own test"
+  assert_not_contains "$c" "npm test"
+}
+
+test_pin_respects_nested_commands_form() {
+  local cfg="$TEST_TMPDIR/cfg.md"
+  printf -- '---\ncommands:\n  test: my nested test\n---\n' >"$cfg"
+  run_script pin-config.sh --config "$cfg" --test "npm test" --typecheck "tsc"
+  assert_rc 0
+  assert_key "$OUT" PINNED "typecheck" # test already set (nested), only typecheck added
+  local c; c=$(cat "$cfg")
+  assert_not_contains "$c" "test_cmd: npm test"
+  assert_contains "$c" "typecheck_cmd: tsc"
+}
+
+test_pin_crlf_config_idempotent() {
+  local cfg="$TEST_TMPDIR/cfg.md"
+  printf -- '---\r\ntest_cmd: existing\r\n---\r\n' >"$cfg"
+  run_script pin-config.sh --config "$cfg" --test "npm test"
+  assert_rc 0
+  assert_key "$OUT" PINNED "" # CRLF-parsed, test seen as already set
+}
+
+test_pin_malformed_config_degrades() {
+  local cfg="$TEST_TMPDIR/cfg.md"
+  printf -- '---\nthis line has no colon\n---\n' >"$cfg"
+  run_script pin-config.sh --config "$cfg" --test "npm test"
+  assert_rc 4
+  assert_key "$OUT" DEGRADED_REASON config-parse-failed
+}
+
+test_pin_inserts_into_existing_frontmatter_preserving_notes() {
+  local cfg="$TEST_TMPDIR/cfg.md"
+  printf -- '---\nbase_branch: dev\n---\n\nHuman notes here\n' >"$cfg"
+  run_script pin-config.sh --config "$cfg" --test "npm test"
+  assert_rc 0
+  local c; c=$(cat "$cfg")
+  assert_contains "$c" "base_branch: dev"
+  assert_contains "$c" "test_cmd: npm test"
+  assert_contains "$c" "Human notes here"
+}
+
+test_pin_single_fence_amended_in_place() {
+  # A hand-edited config with ONE unterminated fence must be amended after that
+  # fence, not wrapped in a second frontmatter (regression: keyed on >=2 fences
+  # would orphan the original). Exactly one fence line must remain.
+  local cfg="$TEST_TMPDIR/cfg.md"
+  printf -- '---\nbase_branch: dev\n' >"$cfg"
+  run_script pin-config.sh --config "$cfg" --test "npm test"
+  assert_rc 0
+  assert_key "$OUT" PINNED "test"
+  local c; c=$(cat "$cfg")
+  assert_contains "$c" "test_cmd: npm test"
+  assert_contains "$c" "base_branch: dev"
+  local fences; fences=$(grep -c '^---' "$cfg")
+  assert_eq 1 "$fences" "single-fence config must not gain a wrapping frontmatter"
+}
+
+test_pin_preserves_backslash_in_command() {
+  # A backslash in a gate command must be written verbatim (regression: awk -v
+  # escape-processes \t into a tab; ENVIRON does not).
+  local cfg="$TEST_TMPDIR/cfg.md"
+  printf -- '---\nbase_branch: dev\n---\n' >"$cfg"
+  run_script pin-config.sh --config "$cfg" --test 'grep -P \t file'
+  assert_rc 0
+  local c; c=$(cat "$cfg")
+  assert_contains "$c" 'test_cmd: grep -P \t file'
+}
+
+test_pin_unwritable_config_degrades() {
+  # A write that cannot land (the parent path is a file, not a dir) must degrade
+  # with exit 4 - never falsely emit PINNED and exit 0 (exit-code contract).
+  local blocker="$TEST_TMPDIR/blocker"
+  printf 'x\n' >"$blocker" # a regular file where a directory is needed
+  run_script pin-config.sh --config "$blocker/issue-to-pr.local.md" --test "npm test"
+  assert_rc 4
+  assert_key "$OUT" DEGRADED_REASON config-write-failed
+  assert_not_contains "$OUT" "PINNED=test"
+}

--- a/plugins/issue-to-pr/tests/contract/test_sensitive-paths.sh
+++ b/plugins/issue-to-pr/tests/contract/test_sensitive-paths.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Contract tests for scripts/sensitive-paths.sh (design D2 security overlay).
+
+sp_run() { # newline-path-list -> sets OUT/RC
+  OUT=$(printf '%s\n' "$1" | bash "$ITP_SCRIPTS/sensitive-paths.sh" 2>/dev/null)
+  RC=$?
+  export OUT RC
+}
+
+test_sp_true_positives() {
+  sp_run "src/auth/login.py
+db/migrations/001_users.sql
+config/.env
+lib/crypto/aes.go
+services/payment/charge.rb
+deploy/id_rsa"
+  assert_key "$OUT" SENSITIVE true
+  assert_contains "$OUT" "src/auth/login.py"
+  assert_contains "$OUT" "config/.env"
+}
+
+test_sp_false_positives_do_not_trip() {
+  # authors.py / thesaurus.md / payment_ui_copy.md must NOT match (segment/stem-exact).
+  sp_run "docs/authors.py
+content/thesaurus.md
+ui/payment_ui_copy.md
+src/authService.notes.md
+README.md"
+  assert_key "$OUT" SENSITIVE false
+}
+
+test_sp_env_variants() {
+  sp_run ".env.production"
+  assert_key "$OUT" SENSITIVE true
+}
+
+test_sp_auth_as_filename_stem() {
+  sp_run "src/services/auth.ts"
+  assert_key "$OUT" SENSITIVE true
+}
+
+test_sp_empty_input() {
+  sp_run ""
+  assert_key "$OUT" SENSITIVE false
+  assert_key "$OUT" MATCHED ""
+}
+
+test_sp_case_insensitive() {
+  sp_run "src/Auth/Login.java"
+  assert_key "$OUT" SENSITIVE true
+}
+
+test_sp_json() {
+  sp_run "src/auth/x.py"
+  # re-run with --json
+  OUT=$(printf '%s\n' "src/auth/x.py" | bash "$ITP_SCRIPTS/sensitive-paths.sh" --json 2>/dev/null)
+  assert_contains "$OUT" '"SENSITIVE":"true"'
+}
+
+test_sp_unterminated_last_line() {
+  # A path with NO trailing newline (e.g. a raw `git diff` tail) must still be
+  # classified - the read loop keeps the final unterminated line.
+  OUT=$(printf '%s' "src/auth/login.py" | bash "$ITP_SCRIPTS/sensitive-paths.sh" 2>/dev/null)
+  assert_key "$OUT" SENSITIVE true
+  assert_contains "$OUT" "src/auth/login.py"
+}

--- a/plugins/issue-to-pr/tests/contract/test_skill-lint.sh
+++ b/plugins/issue-to-pr/tests/contract/test_skill-lint.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Contract tests for the SKILL.md spine (design D8, spec sec 5.7).
+# Enforces the <=140-line budget and that the spine still wires its mechanical
+# scripts (so a future edit can't silently drop the substrate the SKILL relies on).
+
+skill_md() { printf '%s' "$ITP_SCRIPTS/../skills/issue-to-pr/SKILL.md"; }
+
+test_skill_within_line_budget() {
+  local n
+  n=$(wc -l <"$(skill_md)")
+  n=${n// /}
+  if [ "$n" -gt 140 ]; then fail "SKILL.md is $n lines; the budget is <=140 (sec 5.7)"; fi
+}
+
+test_skill_names_spine_scripts() {
+  local c
+  c=$(cat "$(skill_md)")
+  local s
+  for s in preflight.sh worktree.sh run-gates.sh triage-evidence.sh tier-select.sh approve.sh; do
+    assert_contains "$c" "$s" "SKILL spine must invoke $s"
+  done
+}
+
+test_skill_keeps_merge_gate_rule() {
+  # The merge-in-main-session-only safety rule must survive the squeeze.
+  local c
+  c=$(cat "$(skill_md)")
+  assert_contains "$c" "main session"
+}

--- a/plugins/issue-to-pr/tests/contract/test_stage-guard.sh
+++ b/plugins/issue-to-pr/tests/contract/test_stage-guard.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Contract tests for scripts/stage-guard.sh (design D2 finding 15).
+
+sg() { # command -> sets OUT
+  OUT=$(printf '{"tool_name":"Bash","tool_input":{"command":"%s"}}' "$1" | bash "$ITP_SCRIPTS/stage-guard.sh" 2>/dev/null)
+  export OUT
+}
+
+test_sg_denies_add_dash_A() {
+  sg 'git add -A'
+  assert_contains "$OUT" '"permissionDecision":"deny"'
+}
+
+test_sg_denies_add_all_long() {
+  sg 'git add --all'
+  assert_contains "$OUT" '"permissionDecision":"deny"'
+}
+
+test_sg_denies_add_dot() {
+  sg 'git add .'
+  assert_contains "$OUT" '"permissionDecision":"deny"'
+}
+
+test_sg_allows_explicit_paths() {
+  sg 'git add src/foo.ts src/bar.ts'
+  assert_contains "$OUT" '"continue":true'
+  assert_not_contains "$OUT" 'permissionDecision'
+}
+
+test_sg_allows_dot_slash_path() {
+  # ./src is an explicit path, not `git add .`
+  sg 'git add ./src/foo.ts'
+  assert_not_contains "$OUT" 'permissionDecision'
+}
+
+test_sg_denies_add_dashdash_dot() {
+  # `git add -- .` still stages everything and must be denied.
+  sg 'git add -- .'
+  assert_contains "$OUT" '"permissionDecision":"deny"'
+}
+
+test_sg_denies_add_pathspec_root() {
+  # `git add :/` is a magic pathspec for the repo root - denied.
+  sg 'git add :/'
+  assert_contains "$OUT" '"permissionDecision":"deny"'
+}
+
+test_sg_passthrough_non_add_command() {
+  sg 'ls -la'
+  assert_contains "$OUT" '"continue":true'
+  assert_not_contains "$OUT" 'permissionDecision'
+}

--- a/plugins/issue-to-pr/tests/contract/test_tier-select.sh
+++ b/plugins/issue-to-pr/tests/contract/test_tier-select.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Contract tests for scripts/tier-select.sh (design D2, spec sec 5.2 rubric).
+
+tier_run() { # keys-block [args...] -> sets OUT/RC
+  local block=$1; shift
+  OUT=$(printf '%s\n' "$block" | bash "$ITP_SCRIPTS/tier-select.sh" "$@" 2>/dev/null)
+  RC=$?
+  export OUT RC
+}
+
+test_tier_trivial() {
+  tier_run "NEW_THING_HITS=0
+REF_PATHS_EXIST=0
+CHECKLIST_ITEMS=0
+BODY_LENGTH=100
+LABELS="
+  assert_key "$OUT" TIER trivial
+}
+
+test_tier_standard_default() {
+  tier_run "NEW_THING_HITS=0
+REF_PATHS_EXIST=2
+CHECKLIST_ITEMS=2
+BODY_LENGTH=600
+LABELS=bug"
+  assert_key "$OUT" TIER standard
+}
+
+test_tier_borderline_picks_higher() {
+  # Fails one trivial condition (ref>1) -> not trivial -> standard (higher).
+  tier_run "NEW_THING_HITS=0
+REF_PATHS_EXIST=2
+CHECKLIST_ITEMS=0
+BODY_LENGTH=100
+LABELS="
+  assert_key "$OUT" TIER standard
+}
+
+test_tier_complex_via_new_thing() {
+  tier_run "NEW_THING_HITS=1
+REF_PATHS_EXIST=1
+CHECKLIST_ITEMS=0
+BODY_LENGTH=200"
+  assert_key "$OUT" TIER complex
+}
+
+test_tier_complex_via_checklist() {
+  tier_run "NEW_THING_HITS=0
+CHECKLIST_ITEMS=3
+REF_PATHS_EXIST=1
+BODY_LENGTH=200"
+  assert_key "$OUT" TIER complex
+}
+
+test_tier_complex_via_refs() {
+  tier_run "NEW_THING_HITS=0
+CHECKLIST_ITEMS=0
+REF_PATHS_EXIST=3
+BODY_LENGTH=200"
+  assert_key "$OUT" TIER complex
+}
+
+test_tier_complex_via_label() {
+  tier_run "NEW_THING_HITS=0
+CHECKLIST_ITEMS=0
+REF_PATHS_EXIST=1
+BODY_LENGTH=200
+LABELS=bug,design"
+  assert_key "$OUT" TIER complex
+}
+
+test_tier_epic() {
+  tier_run "NEW_THING_HITS=3
+REF_PATHS_EXIST=0
+CHECKLIST_ITEMS=0
+BODY_LENGTH=200"
+  assert_key "$OUT" TIER epic
+}
+
+test_tier_override_wins() {
+  tier_run "NEW_THING_HITS=5
+REF_PATHS_EXIST=0" --tier trivial
+  assert_key "$OUT" TIER trivial
+  assert_key "$OUT" TIER_REASON "--tier override"
+}
+
+test_tier_malformed_numeric_coerced() {
+  tier_run "NEW_THING_HITS=abc
+REF_PATHS_EXIST=
+CHECKLIST_ITEMS=x
+BODY_LENGTH=100
+LABELS="
+  assert_rc 0
+  assert_key "$OUT" TIER trivial # all coerced to 0
+}
+
+test_tier_json_output() {
+  tier_run "NEW_THING_HITS=1" --json
+  assert_contains "$OUT" '"TIER":"complex"'
+}
+
+test_tier_unterminated_last_line() {
+  # The decisive signal on the final line with NO trailing newline must still be
+  # read - otherwise the tier silently falls to trivial (read-loop regression).
+  OUT=$(printf 'BODY_LENGTH=100\nNEW_THING_HITS=1' | bash "$ITP_SCRIPTS/tier-select.sh" 2>/dev/null)
+  RC=$?
+  export OUT RC
+  assert_rc 0
+  assert_key "$OUT" TIER complex
+}

--- a/plugins/issue-to-pr/workflows/design-panel.js
+++ b/plugins/issue-to-pr/workflows/design-panel.js
@@ -1,0 +1,124 @@
+// design-panel.js - autonomous design for a complex issue-to-pr task (spec sec 5.3).
+// Replaces the brainstorming interview: three proposers from distinct angles, two
+// adversarial critics that check claims against the actual code, and one judge that
+// synthesizes a single design. Invoked by the SKILL as:
+//   Workflow({scriptPath: "${CLAUDE_PLUGIN_ROOT}/workflows/design-panel.js",
+//             args: {issue, title, contextFiles:[...], constraints, openQuestions:[...]}})
+// Returns {design_md, rejected_alternatives[], open_questions[]}. The SKILL writes
+// design_md to tmp/task-<N>/design.md and routes preference-bound open_questions to
+// the ledger. Workflow agents have Read/Grep, so contextFiles are paths they read.
+
+export const meta = {
+  name: 'design-panel',
+  description: 'Autonomous design panel for a complex issue: 3 proposers, 2 adversarial critics, 1 opus judge',
+  phases: [
+    { title: 'Propose', detail: 'three angles in parallel' },
+    { title: 'Critique', detail: 'two adversarial critics vs the codebase' },
+    { title: 'Judge', detail: 'opus synthesizes one design' },
+  ],
+}
+
+const a = args || {}
+const issue = a.issue ?? '?'
+const title = a.title ?? ''
+const contextFiles = Array.isArray(a.contextFiles) ? a.contextFiles : []
+const constraints = a.constraints || 'none stated'
+const openQuestions = Array.isArray(a.openQuestions) ? a.openQuestions : []
+
+const ctxLine = contextFiles.length
+  ? `Relevant files to read: ${contextFiles.join(', ')}`
+  : 'Explore the repo (Grep/Glob/Read) to find the relevant files.'
+const base = `Issue #${issue}: ${title}\n${ctxLine}\nConstraints: ${constraints}\nKnown open questions: ${openQuestions.length ? openQuestions.join('; ') : 'none'}`
+
+const DESIGN_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  properties: {
+    approach: { type: 'string' },
+    design_md: { type: 'string' },
+    tradeoffs: { type: 'string' },
+    risks: { type: 'string' },
+  },
+  required: ['approach', 'design_md', 'tradeoffs', 'risks'],
+}
+
+const ANGLES = [
+  { key: 'minimal-change', lens: 'Prefer the smallest change that solves the issue. Reuse existing patterns; avoid new abstractions and files unless clearly warranted.' },
+  { key: 'robustness-first', lens: 'Prefer correctness and failure handling. Make invariants explicit, enumerate edge cases, and plan the tests before the code.' },
+  { key: 'ux-first', lens: 'Prefer the clearest experience for the user or calling code: naming, defaults, and error messages that need no documentation.' },
+]
+
+phase('Propose')
+// Attach each proposal's angle to its result BEFORE filtering, so a failed
+// proposer can't shift the remaining proposals' labels (ANGLES[i] would mislabel).
+const proposals = (await parallel(ANGLES.map(angle => () =>
+  agent(
+    `Propose a design for this issue from the "${angle.key}" angle. ${angle.lens}\n\n${base}\n\nRead the actual code first, then return a concrete design: what changes, in which files, and why; its tradeoffs; and its risks.`,
+    { label: `propose:${angle.key}`, phase: 'Propose', model: 'sonnet', effort: 'high', schema: DESIGN_SCHEMA },
+  ).then(r => (r ? { ...r, _angle: angle.key } : null)),
+))).filter(Boolean)
+
+if (proposals.length === 0) {
+  // Total proposer failure: signal the SKILL to use its next fallback.
+  return { design_md: '', rejected_alternatives: [], open_questions: [], _failed: 'no proposals produced' }
+}
+
+const proposalsText = proposals
+  .map((p, i) => `--- Proposal ${i + 1} (${p._angle}) ---\nApproach: ${p.approach}\nDesign:\n${p.design_md}\nTradeoffs: ${p.tradeoffs}\nRisks: ${p.risks}`)
+  .join('\n\n')
+
+phase('Critique')
+const CRITIQUE_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  properties: {
+    verdicts: {
+      type: 'array',
+      items: {
+        type: 'object', additionalProperties: false,
+        properties: {
+          proposal: { type: 'string' },
+          verdict: { type: 'string', enum: ['kill', 'refine', 'keep'] },
+          why: { type: 'string' },
+        },
+        required: ['proposal', 'verdict', 'why'],
+      },
+    },
+    synthesis_hint: { type: 'string' },
+  },
+  required: ['verdicts', 'synthesis_hint'],
+}
+const critiques = (await parallel([1, 2].map(n => () => agent(
+  `You are adversarial critic ${n} of the candidate designs for:\n${base}\n\n${proposalsText}\n\nRead the actual code to verify each proposal's claims. For each, return kill / refine / keep with a concrete reason grounded in the codebase (a design that reads plausibly but contradicts the code should be killed). Then give one synthesis hint for the strongest combined design.`,
+  { label: `critique:${n}`, phase: 'Critique', model: 'sonnet', effort: 'high', schema: CRITIQUE_SCHEMA },
+)))).filter(Boolean)
+
+phase('Judge')
+const JUDGE_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  properties: {
+    design_md: { type: 'string' },
+    rejected_alternatives: { type: 'array', items: { type: 'string' } },
+    open_questions: {
+      type: 'array',
+      items: {
+        type: 'object', additionalProperties: false,
+        properties: {
+          question: { type: 'string' },
+          preference_bound: { type: 'boolean' },
+          decision_if_auto: { type: 'string' },
+        },
+        required: ['question', 'preference_bound', 'decision_if_auto'],
+      },
+    },
+  },
+  required: ['design_md', 'rejected_alternatives', 'open_questions'],
+}
+const judge = await agent(
+  `You are the design judge for:\n${base}\n\nCandidate designs:\n${proposalsText}\n\nCritiques:\n${JSON.stringify(critiques, null, 2)}\n\nSynthesize ONE design_md (<=200 lines: problem, chosen approach, what changes where, an explicit test plan — anything UI/layout/browser must be verifiable with a visual command or a browser test, not eyeballing — and risks), grafting the best of the runners-up. List rejected_alternatives (one line each with why it lost). List open_questions: set preference_bound=true for public API naming, user-visible UX/copy, paid/external resources, new external dependencies or licenses, or breaking API/schema changes (these go to the human); for everything else set preference_bound=false and give your decision in decision_if_auto.`,
+  { label: 'judge', phase: 'Judge', model: 'opus', effort: 'high', schema: JUDGE_SCHEMA },
+)
+
+if (!judge || !judge.design_md) {
+  // Judge failed or produced nothing usable: signal the SKILL's next fallback.
+  return { design_md: '', rejected_alternatives: [], open_questions: [], _failed: 'judge produced no design' }
+}
+return judge


### PR DESCRIPTION
## What this is

Layer 2 of the issue-to-pr v2 redesign (issue #10), built on the v1.2.0 mechanical substrate. It sizes the pipeline to the task and narrows contact to at most three moments: one batched question after design, the merge gate, and a hard stop.

## What ships

- **Tier scaling.** `tier-select.sh` maps triage signals to trivial / standard / complex / epic with a deterministic, CI-tested rubric, so research depth, design, review level, and report length all size to the task and the cost-scaling cannot silently drift.
- **Ask contract and ledger.** The pipeline decides everything it reasonably can, records each call as asked or auto, and surfaces the auto-decisions in the report and this PR body. At most one batched question per run.
- **Autonomous design panel.** `workflows/design-panel.js` runs three proposers from distinct angles, two adversarial critics that check claims against the real code, and one judge that synthesizes a single design. It replaces the one-question-at-a-time brainstorming interview for complex work. Cheap parallel fan-out for the proposers and critics, opus for the judge.
- **Forked research.** A `context: fork` sub-skill runs raw codebase exploration in an isolated Explore subagent and returns a short cited summary, so exploration never floods the main context.
- **Security overlay.** `sensitive-paths.sh` adds one `/security-review` pass only when the diff touches auth, crypto, secrets, payments, or migrations. Matching is segment/stem-exact, so `authors.py` and `payment_ui_copy.md` do not false-trip.
- **Self-writing config.** `pin-config.sh` pins auto-detected, gate-verified commands to `.claude/issue-to-pr.local.md` through the shared frontmatter parser. It never overwrites a human value, and it fails closed (degrade, exit 4) if the write cannot land.
- **Explicit-staging hook.** `stage-guard.sh` (PreToolUse) denies `git add -A / . / --all / :/` so staging stays explicit.
- **Tune skill.** `/issue-to-pr:tune` turns a friction log into batched skill fixes, replacing the always-on improve-this-skill step.
- **Leaner spine.** SKILL.md is down to 140 lines now that tested scripts own the mechanics. A model-owned `state.json` and an append-only `step.log` let a run resume after a context compaction.

## Decisions made autonomously (per the ask contract)

- Three foundational deviations from the original spec, all approved at design sign-off: a model-owned `state.json` (plus a `step.log` side-car) that scripts never parse, a CI-tested `tier-select.sh` rubric, and the design panel as the primary design path.
- Model casting follows the cost-scaling intent: cheap parallel fan-out for the proposers, critics, and research, and opus for the synthesis judge.

## Testing

- Full contract harness green: 134 tests, plain bash, no jq, verified under Windows Git Bash and Linux/Windows CI.
- shellcheck clean across all 13 scripts.
- Every new script has contract tests (the tier rubric, sensitive-path matching, pin-config idempotency and its write-failure path, stage-guard bypasses) plus a SKILL line-budget lint.
- A five-lens adversarial review of the diff (shell correctness, hook bypass, workflow JS, skill coherence, repo rules) surfaced one real defect: pin-config reported success on a failed write. It is fixed and regression-tested.

## Scope

Second of three trains. Train 3 (v2.0.0, universality) is not in this PR.

Closes #10

https://claude.ai/code/session_01DZKDjA4vgszFenXU1LcbSC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tier-based workflow scaling, with different levels of research, review, and reporting based on task complexity.
  * Introduced a single batched-question checkpoint and clearer decision tracking during the process.
  * Added stronger safeguards for sensitive paths and explicit-path staging, plus improved merge approval handling.

* **Bug Fixes**
  * Improved handling of config pinning, frontmatter parsing, and line-ending consistency.
  * Added support for safer resume behavior and more reliable cleanup after approvals.

* **Documentation**
  * Updated release notes and user-facing guidance to reflect the new workflow and safety rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->