### PR TITLE
fix(issue-to-pr): stop Step 7 from relying on a dead /code-review call

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -130,7 +130,7 @@
     {
       "name": "issue-to-pr",
       "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp files; the issue auto-closes on merge and the board card advances as work moves.",
-      "version": "2.0.3",
+      "version": "2.1.0",
       "author": {
         "name": "Dmitry Yuhanov"
       },

--- a/plugins/issue-to-pr/.claude-plugin/plugin.json
+++ b/plugins/issue-to-pr/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "issue-to-pr",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp files; the issue auto-closes on merge and the board card advances as work moves.",
   "author": {
     "name": "Dmitry Yuhanov"

--- a/plugins/issue-to-pr/CHANGELOG.md
+++ b/plugins/issue-to-pr/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the **issue-to-pr** plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.1.0] - 2026-07-22
+
+### Changed
+- Step 7's review loop now defaults straight to adversarial review subagents instead of first attempting `/code-review`, since most copies of that command block model-invocation and can never fire mid-pipeline anyway
+
 ## [2.0.3] - 2026-07-21
 
 ### Fixed

--- a/plugins/issue-to-pr/README.md
+++ b/plugins/issue-to-pr/README.md
@@ -66,7 +66,9 @@ into the config after a successful run.
 
 Optional companions that sharpen specific steps: `superpowers:*`, `/deep-research`,
 `/cross-review` (from `codex-collaboration`), `humanizer`, and `/code-review`. Each is
-used if installed, with an inline fallback otherwise.
+used if installed, with an inline fallback otherwise. `/code-review` commonly ships
+`disable-model-invocation`, which blocks the pipeline from calling it mid-run regardless
+of install state — the adversarial-subagent fallback is the realistic default for Step 7.
 
 ## Usage
 

--- a/plugins/issue-to-pr/skills/issue-to-pr/SKILL.md
+++ b/plugins/issue-to-pr/skills/issue-to-pr/SKILL.md
@@ -89,7 +89,10 @@ complex+); TDD: failing test → implement → passing. UI/layout work is verifi
 --gate test='<test_cmd>'` (+ `--gate visual=…` for UI). An empty gate command degrades
 (exit 4), never a false green. Red ⇒ STOP and fix. Never proceed red.
 
-**7. Review loop.** `/code-review <level> --fix` at the tier's level, ≤ tier's max passes.
+**7. Review loop.** Default to the inline fallback: independent adversarial review
+subagents critique the diff at the tier's level, ≤ tier's max passes. `/code-review
+<level> --fix` is preferred only when it's actually callable — most copies ship
+`disable-model-invocation`, which blocks a skill run from invoking it at all (`R/companions.md`).
 **Security overlay:** `git diff --name-only "$BASE"...HEAD | S/sensitive-paths.sh`; `SENSITIVE=true`
 → +1 `/security-review`. Track `confirmed_bugs_this_pass`/`gate_fail_streak` in metrics; **escalate a level** on 2+ confirmed bugs/pass or a gate failing twice; re-run gates after each fix.
 

--- a/plugins/issue-to-pr/skills/issue-to-pr/references/companions.md
+++ b/plugins/issue-to-pr/skills/issue-to-pr/references/companions.md
@@ -14,7 +14,7 @@ companion silently degrade quality without saying so.
 | Codebase research (Step 3, complex+) | forked `research` sub-skill (isolated subagent → ≤150-line cited summary); `/deep-research` for external topics | A focused inline exploration distilled to a short summary. |
 | Design generation (Step 4, complex+) | `workflows/design-panel.js` (3 proposers → 2 adversarial critics → opus judge), with `/cross-review` critiquing the produced `design_md` | Inline self-review chain: draft, adversarially self-critique against the code, revise. |
 | Humanizing human-facing text (Step 9–10) | `humanizer` | Self-edit the PR body / report to drop AI-tell phrasing; flag that a humanizer pass would help. |
-| Diff review loop (Step 7) | `/code-review` | A manual diff read for correctness, reuse, and regressions; iterate. |
+| Diff review loop (Step 7) | `/code-review` — only if callable (see note) | Independent adversarial review subagents (2–3 reviewers) critique the diff for correctness, reuse, and regressions; iterate. This is the default in practice. |
 
 ## Install hints (same marketplace)
 
@@ -24,6 +24,15 @@ companion silently degrade quality without saying so.
   plugin and `/codex:setup`.
 - `superpowers:*` is the external Superpowers plugin. `/deep-research` and `/code-review`
   come from your own setup or other plugins.
+
+## Note: `/code-review` is usually unreachable from inside the pipeline
+
+`disable-model-invocation: true` on a command means only a human typing it triggers it —
+the model's own SlashCommand tool cannot invoke it, even from inside a skill run. Most
+`/code-review` copies set this deliberately (it's meant for a human to run directly), so
+Step 7 calling it mid-pipeline is a no-op, not a degraded case: it never fires and the
+inline fallback runs instead. Don't treat "installed" as "callable" — the fallback is the
+realistic default, not a rare miss.
 
 These are recommendations, not requirements — the skill checks availability at the relevant
 step and proceeds either way.


### PR DESCRIPTION
## Summary
- A friction note logged during a pipeline run: `/code-review` is marked `disable-model-invocation`, so Step 7 could never invoke it from inside an automated skill run — the model's SlashCommand tool is blocked, only a human typing it directly works.
- The adversarial-subagent fallback fired instead and found a real bug, so the outcome was fine, but the documented "preferred path" was silently dead.
- Step 7 in `SKILL.md` now defaults straight to spawning adversarial review subagents, with `/code-review` documented as usable only when a copy genuinely allows model invocation.
- Updated `references/companions.md` and `README.md` to stop implying "installed" means "callable" for `/code-review`.
- Bumped `issue-to-pr` to 2.1.0 (`plugin.json` + `marketplace.json`) and added a changelog entry per repo rules.

## Test plan
- [x] `bash plugins/issue-to-pr/tests/run-tests.sh` — 161/161 passed


---
_Generated by [Claude Code](https://claude.ai/code/session_013gn34ufeWJqRwivZXJQyqb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the issue-to-PR workflow’s review step to use independent adversarial review by default.
  * Added a conditional `/code-review` option when the command is callable.
  * Improved guidance explaining when automated review commands cannot be invoked during pipeline runs.
* **Documentation**
  * Updated plugin version information to 2.1.0.
  * Documented the revised review-loop behavior and fallback process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->