### PR TITLE
fix(issue-to-pr): key every gate off one resolved branch name (v2.3.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -130,7 +130,7 @@
     {
       "name": "issue-to-pr",
       "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp files; the issue auto-closes on merge and the board card advances as work moves.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "author": {
         "name": "Dmitry Yuhanov"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -130,7 +130,7 @@
     {
       "name": "issue-to-pr",
       "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp files; the issue auto-closes on merge and the board card advances as work moves.",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "author": {
         "name": "Dmitry Yuhanov"
       },

--- a/plugins/issue-to-pr/.claude-plugin/plugin.json
+++ b/plugins/issue-to-pr/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "issue-to-pr",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp files; the issue auto-closes on merge and the board card advances as work moves.",
   "author": {
     "name": "Dmitry Yuhanov"

--- a/plugins/issue-to-pr/.claude-plugin/plugin.json
+++ b/plugins/issue-to-pr/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "issue-to-pr",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp files; the issue auto-closes on merge and the board card advances as work moves.",
   "author": {
     "name": "Dmitry Yuhanov"

--- a/plugins/issue-to-pr/CHANGELOG.md
+++ b/plugins/issue-to-pr/CHANGELOG.md
@@ -5,9 +5,10 @@ All notable changes to the **issue-to-pr** plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [2.3.1] - 2026-08-16
+## [2.3.2] - 2026-08-17
 
 ### Fixed
+- The documented salvage list names the files cleanup actually copies
 - A PR number now works wherever a branch name does: the merge finds the approval recorded under the branch name instead of refusing it, and cleanup deletes the branch instead of reporting success and leaving it behind
 - A relative `--salvage-to` path lands in the main checkout, not inside the worktree that cleanup is about to remove
 - Cleanup reports what it salvaged even when it then refuses to remove a worktree with uncommitted changes

--- a/plugins/issue-to-pr/CHANGELOG.md
+++ b/plugins/issue-to-pr/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the **issue-to-pr** plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.3.1] - 2026-08-16
+
+### Fixed
+- A PR number now works wherever a branch name does: the merge finds the approval recorded under the branch name instead of refusing it, and cleanup deletes the branch instead of reporting success and leaving it behind
+- A relative `--salvage-to` path lands in the main checkout, not inside the worktree that cleanup is about to remove
+- Cleanup reports what it salvaged even when it then refuses to remove a worktree with uncommitted changes
+
 ## [2.3.0] - 2026-08-16
 
 ### Removed

--- a/plugins/issue-to-pr/scripts/approve.sh
+++ b/plugins/issue-to-pr/scripts/approve.sh
@@ -41,8 +41,7 @@ root=$(repo_root)
 # Canonicalize to the PR's branch name so a PR-number ref and its branch name key the
 # same marker that merge-guard.sh checks. Best-effort: if this fails, fall through with
 # the raw ref -- the sha read right below still degrades cleanly on a bad ref.
-resolved=$(gh pr view "$branch" --json headRefName --jq .headRefName 2>/dev/null || printf '')
-[ -n "$resolved" ] && branch=$resolved
+branch=$(canonical_branch "$branch")
 marker=$(marker_path "$root" "$branch")
 
 sha=$(gh pr view "$branch" --json headRefOid --jq .headRefOid 2>/dev/null || printf '')

--- a/plugins/issue-to-pr/scripts/lib/common.sh
+++ b/plugins/issue-to-pr/scripts/lib/common.sh
@@ -268,6 +268,18 @@ APPROVAL_TTL=1800
 # JSON is hand-written/parsed (no jq): quote is escaped and placed last so a
 # hostile quote cannot spoof the scalar fields parsed before it.
 
+# canonical_branch REF - the branch a gh ref names: a PR number resolves to that PR's
+# head branch, a branch name resolves to itself. An unresolvable ref (no such PR,
+# offline, old gh) comes back UNCHANGED so the caller's own error path still fires.
+# All three gates key the marker through here - approve.sh writing it, merge-guard.sh
+# and worktree.sh merge reading it - because `gh pr merge 42` must find the approval
+# that `approve.sh 42` wrote under the branch name, not miss it and re-ask.
+canonical_branch() {
+  local resolved
+  resolved=$(gh pr view "$1" --json headRefName --jq .headRefName 2>/dev/null) || resolved=""
+  printf '%s' "${resolved:-$1}"
+}
+
 marker_path() { # root branch
   printf '%s/.claude/issue-to-pr/approval-%s.json' "$1" "$(printf '%s' "$2" | tr '/' '-')"
 }

--- a/plugins/issue-to-pr/scripts/merge-guard.sh
+++ b/plugins/issue-to-pr/scripts/merge-guard.sh
@@ -92,8 +92,8 @@ marker=$(marker_path "$root" "$branch")
 # (or vice versa). Resolve to the canonical branch and retry once before denying, so
 # `gh pr merge <PR#>` and `gh pr merge <branch>` always agree on one marker file.
 if [ ! -f "$marker" ]; then
-  resolved=$(gh pr view "$branch" --json headRefName --jq .headRefName 2>/dev/null || printf '')
-  if [ -n "$resolved" ] && [ "$resolved" != "$branch" ]; then
+  resolved=$(canonical_branch "$branch")
+  if [ "$resolved" != "$branch" ]; then
     branch=$resolved
     marker=$(marker_path "$root" "$branch")
   fi

--- a/plugins/issue-to-pr/scripts/worktree.sh
+++ b/plugins/issue-to-pr/scripts/worktree.sh
@@ -101,13 +101,22 @@ detect_deps() { # dir -> sets INSTALL_HINT
   fi
 }
 
-# salvage_artifacts wt salvage_dir issue -> sets SALVAGED. Reports a destination only
-# when something actually landed in it: claiming a salvage that copied nothing is what
-# makes the caller comfortable deleting the originals.
+# salvage_artifacts wt salvage_dir issue root -> sets SALVAGED. Reports a destination
+# only when something actually landed in it: claiming a salvage that copied nothing is
+# what makes the caller comfortable deleting the originals.
+#
+# A relative destination is resolved against the MAIN CHECKOUT, never cwd: both callers
+# are commonly run from inside the worktree, so a cwd-relative dir would be created in
+# the one directory the very next step deletes - the salvage would be reported and then
+# thrown away with the tree it was rescuing files from.
 salvage_artifacts() {
   SALVAGED=""
-  local wt=$1 dst=$2 n=$3 f src copied=0
+  local wt=$1 dst=$2 n=$3 root=$4 f src copied=0
   [ -n "$dst" ] || return 0
+  case "$dst" in
+    /* | ?:/* | ?:\\*) : ;; # already absolute (POSIX, or a Windows drive letter)
+    *) dst="$root/$dst" ;;
+  esac
   mkdir -p "$dst" 2>/dev/null || return 0
   for f in design.md progress.md state.json step.log; do
     src="$wt/tmp/task-$n/$f"
@@ -287,6 +296,11 @@ cmd_merge() {
   root=$(repo_root)
   [ -n "$root" ] || degrade not-a-git-repo "worktree merge: not inside a git repository"
 
+  # Every gh call below accepts a PR number, but the marker is keyed by BRANCH NAME.
+  # Resolve the ref the way approve.sh and merge-guard.sh do, or `merge --branch 42`
+  # hunts for an approval that was written under the branch name and stops on it.
+  branch=$(canonical_branch "$branch")
+
   # -- 1. approval marker: exists  and  unused  and  fresh (<30m)  and  head-SHA match ------
   marker=$(marker_path "$root" "$branch")
   [ -f "$marker" ] || stop no-valid-approval "issue-to-pr: no approval marker for $branch. Run: bash \"$SCRIPT_DIR/approve.sh\" \"$branch\" --quote \"<verbatim reply>\" after judging the reply a go-ahead, then re-run merge."
@@ -415,6 +429,12 @@ cmd_cleanup() {
   root=$(repo_root)
   [ -n "$root" ] || degrade not-a-git-repo "worktree cleanup: not inside a git repository"
 
+  # Same resolution as merge, and for a sharper reason: everything past the gh
+  # precondition below is git, which knows nothing about PR numbers. Given a raw
+  # number, `gh pr view` would report MERGED and then `git branch -D` and the marker
+  # lookup would both silently miss, exiting 0 with the merged branch still there.
+  branch=$(canonical_branch "$branch")
+
   # Hard precondition: the PR must be MERGED. Deleting an open PR's branch is
   # thereby mechanically impossible.
   pr_state=$(gh pr view "$branch" --json state --jq .state 2>/dev/null || printf '')
@@ -425,7 +445,10 @@ cmd_cleanup() {
   wt_path=${reg:-$(compute_wt_path "$root" "$issue")}
 
   # Salvage lasting artifacts before the worktree (and its gitignored files) go.
-  salvage_artifacts "$wt_path" "$salvage_to" "$issue"
+  salvage_artifacts "$wt_path" "$salvage_to" "$issue" "$root"
+  # Reported BEFORE the removal, which flushes the buffer on its way out when the tree
+  # is dirty: a caller whose salvage DID happen would otherwise never be told about it.
+  emit SALVAGED "${SALVAGED:-}"
 
   # Get out of the worktree before removing it.
   cd "$root" 2>/dev/null || true
@@ -466,7 +489,6 @@ cmd_cleanup() {
   emit REMOVED "$REMOVED"
   emit DELETED_LOCAL "$deleted_local"
   emit DELETED_REMOTE "$deleted_remote"
-  emit SALVAGED "${SALVAGED:-}"
   [ -n "$LEFTOVER" ] && emit LEFTOVER_DIR "$LEFTOVER"
   done_ok
 }
@@ -478,7 +500,8 @@ cmd_teardown() {
   reg=$(registered_wt "$issue")
 
   wt_path=${reg:-$(compute_wt_path "$root" "$issue")}
-  salvage_artifacts "$wt_path" "$salvage_to" "$issue"
+  salvage_artifacts "$wt_path" "$salvage_to" "$issue" "$root"
+  emit SALVAGED "${SALVAGED:-}" # before the removal, which can stop and flush (see cleanup)
 
   REMOVED=false
   LEFTOVER=""
@@ -492,7 +515,6 @@ cmd_teardown() {
   fi
 
   emit REMOVED "$REMOVED"
-  emit SALVAGED "${SALVAGED:-}"
   [ -n "$LEFTOVER" ] && emit LEFTOVER_DIR "$LEFTOVER"
   emit KEPT "$kept"
   done_ok

--- a/plugins/issue-to-pr/skills/issue-to-pr/references/contracts.md
+++ b/plugins/issue-to-pr/skills/issue-to-pr/references/contracts.md
@@ -53,7 +53,8 @@ Stops: `bad-checkout-state · stale-unregistered-dir · invalid-start-point · p
 exit `3` → cut the branch in place with `git switch -c <b> <ref>`.
 
 `worktree.sh merge <N> --branch <b> [--ladder-attempt <n>]` — Step 11. The **only** path that
-runs `gh pr merge`. Self-validates the approval marker (present · unused · fresh <30m · head-SHA
+runs `gh pr merge`. `<b>` may be a PR number; it resolves to that PR's branch first, so it keys
+the same marker `approve.sh` wrote whichever form either was given. Self-validates the approval marker (present · unused · fresh <30m · head-SHA
 matches), pushes, then runs the merge-failure ladder (sec 6.3): a structured pre-check classifies
 the PR and emits a typed stop per rung; a clean base merge auto-updates + refreshes the marker +
 merges in one call (`LADDER_STEP=base-merged-refreshed`). On success consumes the marker and
@@ -65,8 +66,10 @@ marker-refresh-failed · checks-pending · merge-ladder-exhausted · merge-faile
 stop, nothing is cleaned up.
 
 `worktree.sh cleanup <N> --branch <b> [--salvage-to <dir>]` — Step 12, after a successful merge.
+`<b>` may be a PR number here too (everything past the precondition is git, which cannot read one).
 Hard precondition: the PR is `MERGED` (else stop `pr-not-merged` — deleting an open PR's branch is
-mechanically impossible). Salvages `tmp/task-<N>/{design,progress,state}` first, removes the
+mechanically impossible). Salvages `tmp/task-<N>/{design,progress,state}` first — a relative
+`--salvage-to` lands under the **main checkout**, not cwd, so it survives the removal — removes the
 worktree (never `--force`; tracked dirtiness → stop `dirty-tracked-files`), deletes the local +
 remote branch, removes the marker. Keys: `REMOVED DELETED_LOCAL DELETED_REMOTE SALVAGED`, plus
 `LEFTOVER_DIR` if a directory could not be removed. **Run it with your shell's cwd in

--- a/plugins/issue-to-pr/skills/issue-to-pr/references/contracts.md
+++ b/plugins/issue-to-pr/skills/issue-to-pr/references/contracts.md
@@ -68,7 +68,7 @@ stop, nothing is cleaned up.
 `worktree.sh cleanup <N> --branch <b> [--salvage-to <dir>]` — Step 12, after a successful merge.
 `<b>` may be a PR number here too (everything past the precondition is git, which cannot read one).
 Hard precondition: the PR is `MERGED` (else stop `pr-not-merged` — deleting an open PR's branch is
-mechanically impossible). Salvages `tmp/task-<N>/{design,progress,state}` first — a relative
+mechanically impossible). Salvages `tmp/task-<N>/{design.md,progress.md,state.json,step.log}` first — a relative
 `--salvage-to` lands under the **main checkout**, not cwd, so it survives the removal — removes the
 worktree (never `--force`; tracked dirtiness → stop `dirty-tracked-files`), deletes the local +
 remote branch, removes the marker. Keys: `REMOVED DELETED_LOCAL DELETED_REMOTE SALVAGED`, plus

--- a/plugins/issue-to-pr/tests/contract/test_worktree.sh
+++ b/plugins/issue-to-pr/tests/contract/test_worktree.sh
@@ -136,6 +136,19 @@ test_wt_merge_happy_consumes_marker() {
   assert_gh_called "pr merge feat/issue-6-x --squash"
 }
 
+# Regression: cmd_merge keyed the marker off the raw --branch value while approve.sh
+# and merge-guard.sh both canonicalize a PR number first, so `--branch 13` looked for
+# a marker nobody had written and the merge stopped on an approval that existed.
+test_wt_merge_resolves_pr_number_to_marker() {
+  local repo wt; repo=$(mk_repo); wt=$(mk_worktree "$repo" feat/issue-6-x); cd "$wt"
+  write_marker "$repo" feat/issue-6-x "$SHA_OK" false "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  use_fake_gh happy
+  run_script worktree.sh merge 6 --branch 13
+  assert_rc 0
+  assert_key "$OUT" MERGED true
+  assert_gh_called "pr merge feat/issue-6-x --squash"
+}
+
 test_wt_merge_squash_disallowed_falls_back_to_merge() {
   local repo wt; repo=$(mk_repo); wt=$(mk_worktree "$repo" feat/issue-6-x); cd "$wt"
   write_marker "$repo" feat/issue-6-x "$SHA_OK" false "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -221,6 +234,53 @@ test_wt_cleanup_salvages_then_removes() {
   assert_rc 0
   assert_key "$OUT" REMOVED true
   if [ ! -f "$TEST_TMPDIR/salvage/design.md" ]; then fail "design.md not salvaged"; fi
+}
+
+# Regression: cleanup keyed the branch off the raw --branch too. `gh pr view 13` still
+# reported MERGED, then every git step missed - the merged branch survived local and
+# remote, the marker stayed behind, and the script exited 0 as if it had cleaned up.
+test_wt_cleanup_resolves_pr_number_to_the_branch() {
+  local repo wt; repo=$(mk_repo); wt=$(mk_worktree "$repo" feat/issue-6-x); cd "$repo"
+  write_marker "$repo" feat/issue-6-x "$SHA_OK" false "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  use_fake_gh pr-merged
+  run_script worktree.sh cleanup 6 --branch 13
+  assert_rc 0
+  assert_key "$OUT" DELETED_LOCAL true
+  if git -C "$repo" show-ref --verify --quiet refs/heads/feat/issue-6-x; then
+    fail "cleanup by PR number left the merged branch behind"
+  fi
+  if [ -f "$repo/.claude/issue-to-pr/approval-feat-issue-6-x.json" ]; then
+    fail "cleanup by PR number left the approval marker behind"
+  fi
+}
+
+# Regression: a relative --salvage-to was resolved against cwd, so a cleanup run from
+# inside the worktree copied the artifacts into the directory it was about to remove.
+test_wt_cleanup_relative_salvage_resolves_against_the_main_checkout() {
+  local repo wt; repo=$(mk_repo); wt=$(mk_worktree "$repo" feat/issue-6-x)
+  mkdir -p "$wt/tmp/task-6"
+  printf '# design\n' >"$wt/tmp/task-6/design.md"
+  cd "$wt"
+  use_fake_gh pr-merged
+  run_script worktree.sh cleanup 6 --branch feat/issue-6-x --salvage-to salvaged
+  assert_rc 0
+  if [ ! -f "$repo/salvaged/design.md" ]; then fail "relative salvage did not land in the main checkout"; fi
+  if [ -f "$wt/salvaged/design.md" ]; then fail "salvage landed in the worktree being removed"; fi
+}
+
+# Regression: SALVAGED was emitted after remove_worktree, which flushes the buffer on
+# its way out when the tree is dirty - so a caller whose salvage HAD happened was never
+# told, and had no reason to trust the copies it could not see reported.
+test_wt_cleanup_reports_salvage_even_when_removal_stops() {
+  local repo wt; repo=$(mk_repo); wt=$(mk_worktree "$repo" feat/issue-6-x); cd "$repo"
+  mkdir -p "$wt/tmp/task-6"
+  printf '# design\n' >"$wt/tmp/task-6/design.md"
+  printf 'changed\n' >>"$wt/README.md" # tracked modification -> removal stops
+  use_fake_gh pr-merged
+  run_script worktree.sh cleanup 6 --branch feat/issue-6-x --salvage-to "$TEST_TMPDIR/salvage"
+  assert_rc 2
+  assert_key "$OUT" STOP_REASON dirty-tracked-files
+  assert_key "$OUT" SALVAGED "$TEST_TMPDIR/salvage"
 }
 
 test_wt_cleanup_in_place_deletes_checked_out_branch() {


### PR DESCRIPTION
Three findings deferred out of the v3 review passes, all in the same cleanup path.

## What changed

`canonical_branch()` now lives in `lib/common.sh`, and every place that keys an approval marker goes through it: `approve.sh` writing one, `merge-guard.sh` and `worktree.sh merge` reading one, `worktree.sh cleanup` removing one. A PR number and its branch name always name the same file now. Cleanup got the same line for a sharper reason: past its `gh` precondition everything is git, which cannot read a PR number, so `cleanup --branch 42` used to exit 0 while the merged branch sat there local and remote and the marker stayed behind.

A relative `--salvage-to` resolves against the main checkout instead of cwd. Both callers are usually run from inside the worktree, so the old behaviour built the salvage directory in the one place the next step deletes.

`SALVAGED` is emitted before `remove_worktree` rather than after. That function flushes the output buffer and stops when the tree carries tracked changes, so a caller whose salvage had already happened was never told about it.

## Decisions made autonomously

- Preflight found no test command, so the gates ran `bash plugins/issue-to-pr/tests/run-tests.sh`. The runner exists, it just sits under `plugins/issue-to-pr/` while preflight looks in the cwd root, which is issue #17. Pinned into the local config so the next run finds it.
- The two duplicated lines became a shared helper instead of a fourth copy. `common.sh` already owns every marker primitive, and four hand-written copies of one gate are four chances to drift.
- Relative salvage paths are resolved inside `salvage_artifacts`, which covers cleanup and teardown from a single place.

## Rejected alternatives

- Canonicalizing once in the argument parser, for every subcommand. That puts a `gh pr view` in front of `ensure`, where the branch is new and has no PR by definition.
- Leaving cleanup out as beyond the issue's scope. The review pass argued that this change's own documentation invites a PR number into cleanup, so the scope had to follow it.

## Tests

Four regression tests, each red against the old code: merge and cleanup by PR number, a relative salvage path, and the salvage report surviving a dirty stop. Full suite green, shellcheck clean over 14 files, 195/195 contract tests.

Closes #16


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Merge and cleanup commands now accept pull request numbers as branch identifiers.
  * Relative salvage destinations are resolved from the main checkout.
  * Cleanup reports salvaged work before worktree removal.

* **Bug Fixes**
  * Improved branch resolution and approval-marker handling for pull request inputs.
  * Fixed salvage and cleanup behavior when uncommitted changes prevent worktree removal.

* **Documentation**
  * Updated usage contracts and changelog for the new behavior.

* **Chores**
  * Released version 2.3.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->