### PR TITLE
fix(issue-to-pr): resolve every Step-0 probe against the repository, not the caller's cwd (v2.4.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -130,7 +130,7 @@
     {
       "name": "issue-to-pr",
       "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp files; the issue auto-closes on merge and the board card advances as work moves.",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "author": {
         "name": "Dmitry Yuhanov"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -130,7 +130,7 @@
     {
       "name": "issue-to-pr",
       "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp files; the issue auto-closes on merge and the board card advances as work moves.",
-      "version": "2.3.2",
+      "version": "2.4.0",
       "author": {
         "name": "Dmitry Yuhanov"
       },

--- a/plugins/issue-to-pr/.claude-plugin/plugin.json
+++ b/plugins/issue-to-pr/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "issue-to-pr",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp files; the issue auto-closes on merge and the board card advances as work moves.",
   "author": {
     "name": "Dmitry Yuhanov"

--- a/plugins/issue-to-pr/.claude-plugin/plugin.json
+++ b/plugins/issue-to-pr/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "issue-to-pr",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp files; the issue auto-closes on merge and the board card advances as work moves.",
   "author": {
     "name": "Dmitry Yuhanov"

--- a/plugins/issue-to-pr/CHANGELOG.md
+++ b/plugins/issue-to-pr/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the **issue-to-pr** plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.4.0] - 2026-08-17
+
+### Added
+- A repository whose only test runner sits inside a project rather than at the top is now detected, so long as there is exactly one of them and it is tracked. Two or more stay ambiguous on purpose and are pinned in the config instead ([#23](https://github.com/DmitriyYukhanov/claude-plugins/issues/23))
+
+### Fixed
+- Gate-command detection answers the same thing whatever directory you start the run from; it used to read the caller's working directory and report no test command for a project that has one
+- The pinned config is found from anywhere in the repository. Started from a subdirectory, a run used to miss it entirely and quietly replace your pinned test command, base branch and board with guesses
+- A `check:`-only Makefile reports `make check` instead of a `make typecheck` that does not exist and stopped the run on a red gate
+
 ## [2.3.2] - 2026-08-17
 
 ### Fixed

--- a/plugins/issue-to-pr/CHANGELOG.md
+++ b/plugins/issue-to-pr/CHANGELOG.md
@@ -5,15 +5,16 @@ All notable changes to the **issue-to-pr** plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [2.4.0] - 2026-08-17
+## [2.4.1] - 2026-08-18
 
 ### Added
-- A repository whose only test runner sits inside a project rather than at the top is now detected, so long as there is exactly one of them and it is tracked. Two or more stay ambiguous on purpose and are pinned in the config instead ([#23](https://github.com/DmitriyYukhanov/claude-plugins/issues/23))
+- Detect a test runner that lives inside a project, when the repository has exactly one tracked runner and none at the top
+- Leave two or more runners ambiguous and report no test command, so the one you want gets pinned in the config ([#23](https://github.com/DmitriyYukhanov/claude-plugins/issues/23))
 
 ### Fixed
-- Gate-command detection answers the same thing whatever directory you start the run from; it used to read the caller's working directory and report no test command for a project that has one
-- The pinned config is found from anywhere in the repository. Started from a subdirectory, a run used to miss it entirely and quietly replace your pinned test command, base branch and board with guesses
-- A `check:`-only Makefile reports `make check` instead of a `make typecheck` that does not exist and stopped the run on a red gate
+- Resolve every Step-0 probe against the repository, so gate detection no longer depends on the directory you start the run from
+- Find the pinned config from anywhere in the repository; a run started from a subdirectory used to miss it and replace your pinned test command, base branch and board with guesses
+- Report `make check` for a `check:`-only Makefile, instead of a `make typecheck` that no rule defines and that stopped the run on a red gate
 
 ## [2.3.2] - 2026-08-17
 

--- a/plugins/issue-to-pr/scripts/lib/common.sh
+++ b/plugins/issue-to-pr/scripts/lib/common.sh
@@ -199,6 +199,22 @@ repo_root() {
   git rev-parse --show-toplevel 2>/dev/null || printf ''
 }
 
+# resolve_under ROOT PATH - PATH unchanged when it is already absolute (POSIX, or a
+# Windows drive letter in either slash), else PATH resolved under ROOT. Every path this
+# plugin keys off something other than the caller's cwd goes through here: preflight's
+# config file and worktree.sh's --salvage-to destination both used to be cwd-relative,
+# and both landed somewhere the caller never meant when the run was not started from
+# the repository root.
+# A `\\server\share` UNC path is absolute without starting in a slash at all; missing it
+# resolved a network path under the root, where nothing is. (`//server/share` needs no
+# pattern of its own - `/*` already matches it.)
+resolve_under() {
+  case "$2" in
+    /* | \\\\* | ?:/* | ?:\\*) printf '%s' "$2" ;;
+    *) printf '%s/%s' "$1" "$2" ;;
+  esac
+}
+
 # assert_numeric_issue VALUE SCRIPT - the issue number is the only caller-supplied
 # value that gets spliced into a state-dir or worktree path, and those paths are
 # later handed to `rm -rf`. A token carrying `..` (a fabricated number, a fragment

--- a/plugins/issue-to-pr/scripts/preflight.sh
+++ b/plugins/issue-to-pr/scripts/preflight.sh
@@ -312,11 +312,21 @@ if [ -z "$det_test" ]; then
     mapfile -t _runners < <(
       git -C "$det_root" ls-files --cached -- '*/run-tests.sh' 2>/dev/null | sort
     )
+    # Emitted BARE, and only when the path cannot change how a shell reads it. The value
+    # is evaluated twice - run-gates.sh hands it to `bash -c`, and Step 6 substitutes it
+    # into `--gate test='<cmd>'` - so no single quoting scheme survives both: double
+    # quotes let a directory named `$(...)` execute at gate time (a repository you have
+    # merely cloned is enough), and single quotes are ended by the wrapper. A path
+    # carrying anything else is left undetected, which is the honest outcome: Step 6
+    # degrades loudly and pin-config.sh names the command.
     if [ "${#_runners[@]}" = 1 ]; then
-      # Quoted: run-gates.sh hands the value to `bash -c`, so a project directory with
-      # a space in its name would otherwise arrive as two arguments.
-      det_test="bash \"${_runners[0]}\""
-      det_source_test=${_runners[0]}
+      case ${_runners[0]} in
+        *[!A-Za-z0-9._/-]*) : ;;
+        *)
+          det_test="bash ${_runners[0]}"
+          det_source_test=${_runners[0]}
+          ;;
+      esac
     fi
   fi
 fi

--- a/plugins/issue-to-pr/scripts/preflight.sh
+++ b/plugins/issue-to-pr/scripts/preflight.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # preflight.sh - one Step-0 probe that replaces ~8 separate model tool calls
-# (spec sec 4.1). Run once from the MAIN checkout. Reports auth/scopes, repo
+# (spec sec 4.1). Run once, from anywhere in the repository: the config, the gate
+# commands and the worktree state all resolve against the main checkout, so the
+# answer does not depend on the directory you started in. The commands it reports
+# are relative to the repository root, which is where the gates run. Reports
+# auth/scopes, repo
 # identity, resolved base + start-point, auto-detected gate commands (overridden
 # by config), issue state/assignees, the issue-<N> worktree state, and board
 # membership. Never mutates anything except `--claim` (assign issue to @me).
@@ -22,11 +26,12 @@ source "$SCRIPT_DIR/lib/common.sh"
 issue=""
 claim=0
 config_path=".claude/issue-to-pr.local.md"
+config_from_flag=0
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --claim) claim=1; shift ;;
-    --config) config_path=${2:-}; shift 2 2>/dev/null || shift "$#" ;;
+    --config) config_path=${2:-}; config_from_flag=1; shift 2 2>/dev/null || shift "$#" ;;
     -*) warn "preflight: ignoring unknown flag: $1"; shift ;;
     *) [ -z "$issue" ] && issue=$1; shift ;;
   esac
@@ -84,6 +89,27 @@ set_cfg() { # top sub value
 }
 
 # trim_quotes + parse_frontmatter now live in lib/common.sh (shared with pin-config.sh).
+
+# The config is read from the MAIN checkout, resolved before anything reads it. It was
+# the one cwd-relative path left in this script, and it outranks auto-detect: a run
+# started from a subdirectory found no config at all and silently swapped the pinned
+# test command for whatever auto-detect guessed, taking the pinned base branch and the
+# board with it.
+#
+# The main checkout and not the current tree, because the file is usually untracked
+# (`pin-config.sh` writes it there and nothing commits it), so a worktree simply has no
+# copy. A repository that DOES commit it is read from the main checkout too, which means
+# a branch changing the config is gated by the version on the base - a wart, not a
+# hazard, and one the pinned values being explicit makes visible.
+root=$(repo_root)
+# `git worktree list` puts a BARE repository first, and a bare directory holds neither
+# the config nor a project to probe: `.git` (a dir in a checkout, a file in a linked
+# worktree) is missing there, so fall back to the tree we are standing in.
+[ -e "${root:-.}/.git" ] || root=$(git rev-parse --show-toplevel 2>/dev/null || printf '')
+# Only the DEFAULT path is re-rooted. An explicit --config is a caller's instruction and
+# stays relative to the caller, which is also how every in-tree caller already passes it
+# (SKILL Step 8 hands it an absolute path).
+[ "$config_from_flag" = 1 ] || config_path=$(resolve_under "${root:-.}" "$config_path")
 
 config_present=false
 if [ -f "$config_path" ]; then
@@ -205,45 +231,94 @@ else
 fi
 
 # -- gate command auto-detect (config overrides) ------------------------------
+# Every probe below is anchored to a checkout root, never to cwd: a run started from a
+# subdirectory used to report "no test command" for a project that plainly has one, and
+# Step 6 then had nothing left to verify the work with.
+#
+# Probed in the main checkout, never in "whatever tree cwd happens to be in": started
+# from issue-5's worktree, a run for issue 9 would otherwise gate issue 9 on a project
+# that exists only on issue 5's branch. Anchoring this to the worktree the run will
+# actually use is a different job and cannot be done here anyway - Step 0 probes before
+# Step 1 has cut that worktree from `origin/$base`, so the tree the gates will run in
+# does not exist yet.
+det_root=${root:-.}
 det_test="" det_typecheck="" det_visual="" det_smoke="" det_source="none"
 detect_from_package_json() {
+  local pkg="$det_root/package.json"
   det_source="package.json"
-  grep -qE '"test"[[:space:]]*:' package.json && det_test='npm test'
+  grep -qE '"test"[[:space:]]*:' "$pkg" && det_test='npm test'
   local k
   for k in typecheck tsc type-check; do
-    if grep -qE "\"$k\"[[:space:]]*:" package.json; then det_typecheck="npm run $k"; break; fi
+    if grep -qE "\"$k\"[[:space:]]*:" "$pkg"; then det_typecheck="npm run $k"; break; fi
   done
   for k in 'test:visual' visual e2e playwright; do
-    if grep -qE "\"$k\"[[:space:]]*:" package.json; then det_visual="npm run $k"; break; fi
+    if grep -qE "\"$k\"[[:space:]]*:" "$pkg"; then det_visual="npm run $k"; break; fi
   done
-  grep -qE '"smoke"[[:space:]]*:' package.json && det_smoke='npm run smoke'
+  grep -qE '"smoke"[[:space:]]*:' "$pkg" && det_smoke='npm run smoke'
 }
-if [ -f package.json ]; then
+if [ -f "$det_root/package.json" ]; then
   detect_from_package_json
-elif [ -f Cargo.toml ]; then
+elif [ -f "$det_root/Cargo.toml" ]; then
   det_source="Cargo.toml"; det_test='cargo test'; det_typecheck='cargo check'
-elif [ -f go.mod ]; then
+elif [ -f "$det_root/go.mod" ]; then
   det_source="go.mod"; det_test='go test ./...'; det_typecheck='go vet ./...'
-elif [ -f pyproject.toml ] || [ -f setup.py ]; then
+elif [ -f "$det_root/pyproject.toml" ] || [ -f "$det_root/setup.py" ]; then
   det_source="python"; det_test='pytest'
-elif [ -f Makefile ]; then
+elif [ -f "$det_root/Makefile" ]; then
   det_source="Makefile"
-  grep -qE '^test:' Makefile && det_test='make test'
-  grep -qE '^(typecheck|check):' Makefile && det_typecheck='make typecheck'
+  grep -qE '^test:' "$det_root/Makefile" && det_test='make test'
+  # Emit the target that is actually there. A `check:`-only Makefile (the GNU spelling)
+  # used to yield `make typecheck`, which make then refuses for want of such a rule -
+  # a red gate on a repository with nothing wrong, and nothing telling the model the
+  # command had been invented rather than read.
+  for k in typecheck check; do
+    if grep -qE "^$k:" "$det_root/Makefile"; then det_typecheck="make $k"; break; fi
+  done
 fi
 
 # Shell-harness projects - plugin repos, dotfiles, anything where a runner script
 # IS the suite. Checked after the manifests so a real one still wins, but it also
 # rescues a manifest that declares no test at all; without this the Step 6 gate
 # degrades to "no command" and the run proceeds with nothing verifying it.
+# A runner at the top wins outright. Failing that, the repository is asked for its
+# TRACKED runners and exactly ONE is accepted, so a plugin or package monorepo that
+# keeps <project>/tests/run-tests.sh is still found.
+#
+# Deliberately no command assembled from several runners. Step 0 cannot enumerate
+# projects honestly: it probes THIS checkout, while the gates run in a worktree Step 1
+# cuts from `origin/$base` afterwards, so any enumeration can disagree with the tree
+# under test - and one stale link then either hides a red suite or kills the whole
+# command. Two or more runners therefore stay ambiguous on purpose: no test command is
+# reported and `pin-config.sh` is the documented way to name the right one. The
+# multi-suite case and what it would take is #23.
+#
+# Tracked, because an ignored scratch project or an untracked leftover is not in the
+# worktree the gates run in, so a command naming it dies there at 127. The top-level
+# probe below keeps its long-standing behaviour and accepts an untracked runner too.
+harness_entry() { # dir relative to det_root ("" = its top) -> the runner path, or nothing
+  local d=$1 h p
+  for h in tests/run-tests.sh test/run-tests.sh scripts/run-tests.sh run-tests.sh; do
+    p=${d:+$d/}$h
+    if [ -f "$det_root/$p" ]; then printf '%s' "$p"; return 0; fi
+  done
+  return 1
+}
 det_source_test=""
 if [ -z "$det_test" ]; then
-  for h in tests/run-tests.sh test/run-tests.sh scripts/run-tests.sh run-tests.sh; do
-    [ -f "$h" ] || continue
-    det_test="bash $h"
-    det_source_test=$h
-    break
-  done
+  if harness=$(harness_entry ""); then
+    det_test="bash $harness"
+    det_source_test=$harness
+  else
+    mapfile -t _runners < <(
+      git -C "$det_root" ls-files --cached -- '*/run-tests.sh' 2>/dev/null | sort
+    )
+    if [ "${#_runners[@]}" = 1 ]; then
+      # Quoted: run-gates.sh hands the value to `bash -c`, so a project directory with
+      # a space in its name would otherwise arrive as two arguments.
+      det_test="bash \"${_runners[0]}\""
+      det_source_test=${_runners[0]}
+    fi
+  fi
 fi
 
 # Config wins over auto-detect; track the source per command.
@@ -291,11 +366,11 @@ if [ "$claim" = 1 ]; then
 fi
 
 # -- worktree state for issue-<N> ---------------------------------------------
-# Same root as the config and the state dir. `git rev-parse --show-toplevel`
-# returns the WORKTREE's own root when preflight runs from inside one, which would
+# `$root` (resolved once above, for the gate probes too) is the MAIN checkout, the
+# same root as the config and the state dir. `git rev-parse --show-toplevel` would
+# return the WORKTREE's own root when preflight runs from inside one, which would
 # compute `<repo>-worktrees/issue-N-worktrees/issue-N` and report `absent` for a
 # worktree the caller is standing in.
-root=$(repo_root)
 wt_state="absent"
 wt_path=""
 if [ -n "$root" ]; then

--- a/plugins/issue-to-pr/scripts/worktree.sh
+++ b/plugins/issue-to-pr/scripts/worktree.sh
@@ -113,10 +113,7 @@ salvage_artifacts() {
   SALVAGED=""
   local wt=$1 dst=$2 n=$3 root=$4 f src copied=0
   [ -n "$dst" ] || return 0
-  case "$dst" in
-    /* | ?:/* | ?:\\*) : ;; # already absolute (POSIX, or a Windows drive letter)
-    *) dst="$root/$dst" ;;
-  esac
+  dst=$(resolve_under "$root" "$dst")
   mkdir -p "$dst" 2>/dev/null || return 0
   for f in design.md progress.md state.json step.log; do
     src="$wt/tmp/task-$n/$f"

--- a/plugins/issue-to-pr/skills/issue-to-pr/references/configuration.md
+++ b/plugins/issue-to-pr/skills/issue-to-pr/references/configuration.md
@@ -51,6 +51,13 @@ as an alias for the top-level `*_cmd` scalars.)
 
 `preflight.sh` (Step 0) parses this file and, for any command it does not find, auto-detects one
 from the project's manifests (`package.json` scripts, then `Cargo.toml` / `go.mod` / `pyproject`
-/ `Makefile`). Config always wins over auto-detection; the reported `CMD_SOURCE_*` keys say which
-source each command came from. If neither a config value nor a detected command exists, ask the
+/ `Makefile`), falling back to a shell runner (`tests/run-tests.sh` and its usual spellings).
+No probe reads the directory you happen to run from: everything resolves against the **main
+checkout**, which is where the config lives and the only tree that is certain to exist when
+Step 0 runs. A runner at the top wins outright; failing that, a single **tracked** runner
+inside a project is accepted, so a plugin or package monorepo is still found. Two or more are
+left ambiguous on purpose, and reported as no test command, because Step 0 cannot honestly
+enumerate projects for a worktree Step 1 has not cut yet: pin the command you want
+([#23](https://github.com/DmitriyYukhanov/claude-plugins/issues/23)). Config always wins over auto-detection;
+the reported `CMD_SOURCE_*` keys say which source each command came from. If neither a config value nor a detected command exists, ask the
 user once and suggest saving it here. Never invent a command.

--- a/plugins/issue-to-pr/skills/issue-to-pr/references/contracts.md
+++ b/plugins/issue-to-pr/skills/issue-to-pr/references/contracts.md
@@ -28,13 +28,17 @@ decision. This file is the reference: what to call, when, and how to read the re
 3. **A conflict is a stop, not a fix.** Content conflicts, branch protection, failed checks →
    the script exits 2 and hands control back. Report the exact error; do not auto-resolve.
 
-## preflight.sh — Step 0 probe (run once, from the main checkout)
+## preflight.sh — Step 0 probe (run once, from anywhere in the repository)
 
 `preflight.sh <N> [--claim] [--config <path>]`
 
 Collapses auth, repo identity, base resolution, gate-command detection, issue state, worktree
 state, and board membership into one call. `--claim` assigns the issue to you (warns, does not
-steal, if someone else holds it).
+steal, if someone else holds it). Every probe resolves against the main checkout, so the answer
+does not change with the directory you start in; a relative `--config` you pass yourself is the
+one exception and stays relative to you. The `CMD_*` values are **repository-root-relative and
+must not be split** — run the gates from the root of your checkout (Step 1's `cd WT_PATH`, or
+the repository root in the exit-3 in-place fallback), or a root-relative runner path exits 127.
 
 Keys: `GH_OK SCOPES OWNER REPO DEFAULT_BRANCH BASE START_POINT CMD_TYPECHECK CMD_TEST CMD_VISUAL
 CMD_SMOKE CMD_SOURCE_TEST CMD_SOURCE_TYPECHECK CONFIG_PRESENT ISSUE_STATE ISSUE_TITLE

--- a/plugins/issue-to-pr/tests/contract/test_common.sh
+++ b/plugins/issue-to-pr/tests/contract/test_common.sh
@@ -133,3 +133,32 @@ test_common_marker_refresh_reports_a_rewrite_that_changed_nothing() {
     fail "marker_refresh reported success after changing nothing"
   fi
 }
+
+# resolve_under is what keeps two cwd-sensitive paths honest: preflight's config file and
+# worktree.sh's --salvage-to destination. A Windows form it fails to recognise as absolute
+# gets silently buried under the repo root, where neither of them is ever found again.
+# Every value is built from one unambiguous backslash rather than written as a literal:
+# counting backslashes through layers of quoting is how the first version of this test
+# came to assert something other than what it meant.
+test_common_resolve_under_keeps_absolute_paths() {
+  source "$ITP_SCRIPTS/lib/common.sh"
+  local bs drive unc
+  bs=$(printf '\\')
+  drive="C:${bs}x.md"                 # C:\x.md
+  unc="$bs$bs""nas${bs}team${bs}x.md" # \\nas\team\x.md
+  assert_eq '/etc/x.md' "$(resolve_under /ROOT /etc/x.md)" 'POSIX absolute'
+  assert_eq 'C:/x.md' "$(resolve_under /ROOT C:/x.md)" 'drive letter, forward slash'
+  assert_eq "$drive" "$(resolve_under /ROOT "$drive")" 'drive letter, backslash'
+  assert_eq "$unc" "$(resolve_under /ROOT "$unc")" 'UNC share'
+  assert_eq '//nas/team/x.md' "$(resolve_under /ROOT //nas/team/x.md)" 'UNC, forward slashes'
+}
+
+test_common_resolve_under_roots_a_relative_path() {
+  source "$ITP_SCRIPTS/lib/common.sh"
+  local bs
+  bs=$(printf '\\')
+  assert_eq '/ROOT/.claude/c.md' "$(resolve_under /ROOT .claude/c.md)"
+  assert_eq '/ROOT/C:not-a-drive/c.md' "$(resolve_under /ROOT C:not-a-drive/c.md)" 'drive-relative is not absolute'
+  # ONE leading backslash is not a UNC share, so it still gets rooted.
+  assert_eq "/ROOT/${bs}single" "$(resolve_under /ROOT "${bs}single")" 'single backslash'
+}

--- a/plugins/issue-to-pr/tests/contract/test_preflight.sh
+++ b/plugins/issue-to-pr/tests/contract/test_preflight.sh
@@ -228,6 +228,203 @@ test_preflight_detects_shell_test_harness() {
   assert_key "$OUT" CMD_SOURCE_TEST tests/run-tests.sh
 }
 
+# Regression: every gate-command probe ran against the caller's cwd while repo
+# identity, the config and the worktree state all resolved against the repository
+# root, so a run from any subdirectory reported no test command for a project that
+# has one - and Step 6 then had nothing to verify the work with.
+test_preflight_detects_the_harness_from_a_subdirectory() {
+  local repo
+  repo=$(init_repo)
+  cd "$repo"
+  mkdir -p tests sub/deeper
+  printf '#!/usr/bin/env bash\n' >tests/run-tests.sh
+  cd sub/deeper
+  use_fake_gh happy
+  run_script preflight.sh 6
+  assert_key "$OUT" CMD_TEST "bash tests/run-tests.sh"
+}
+
+test_preflight_detects_package_json_from_a_subdirectory() {
+  local repo
+  repo=$(init_repo)
+  cd "$repo"
+  printf '%s\n' '{ "scripts": { "test": "jest" } }' >package.json
+  mkdir -p sub
+  cd sub
+  use_fake_gh happy
+  run_script preflight.sh 6
+  assert_key "$OUT" CMD_TEST "npm test"
+  assert_key "$OUT" CMD_SOURCE_TEST package.json
+}
+
+# A plugin or package monorepo keeps its runner under the project, not at the top. The
+# path is quoted because run-gates.sh hands the value to `bash -c`.
+test_preflight_finds_a_nested_harness() {
+  local repo
+  repo=$(init_repo)
+  cd "$repo"
+  mkdir -p plugins/foo/tests
+  printf '#!/usr/bin/env bash\n' >plugins/foo/tests/run-tests.sh
+  git add plugins/foo/tests/run-tests.sh
+  use_fake_gh happy
+  run_script preflight.sh 6
+  assert_key "$OUT" CMD_TEST 'bash "plugins/foo/tests/run-tests.sh"'
+  assert_key "$OUT" CMD_SOURCE_TEST plugins/foo/tests/run-tests.sh
+}
+
+# Two runners are ambiguous ON PURPOSE. Assembling a command from both cannot be honest
+# here: Step 0 probes this checkout while the gates run in a worktree cut from
+# origin/$base afterwards, so an enumeration can disagree with the tree under test, and
+# one stale link either hides a red suite or kills the whole command. No command means
+# Step 6 degrades loudly and pin-config names the right one (#23).
+test_preflight_two_nested_harnesses_stay_ambiguous() {
+  local repo
+  repo=$(init_repo)
+  cd "$repo"
+  mkdir -p plugins/a/tests plugins/b/tests
+  printf '#!/usr/bin/env bash\n' >plugins/a/tests/run-tests.sh
+  printf '#!/usr/bin/env bash\n' >plugins/b/tests/run-tests.sh
+  git add plugins/a/tests/run-tests.sh plugins/b/tests/run-tests.sh
+  use_fake_gh happy
+  run_script preflight.sh 6
+  assert_key "$OUT" CMD_TEST ""
+  assert_key "$OUT" CMD_SOURCE_TEST none
+}
+
+# An untracked runner is not in the worktree the gates run in, so a command naming it
+# would die there at 127 on a repository whose own suite is fine.
+test_preflight_untracked_nested_harness_is_not_used() {
+  local repo
+  repo=$(init_repo)
+  cd "$repo"
+  mkdir -p plugins/foo/tests
+  printf '#!/usr/bin/env bash\n' >plugins/foo/tests/run-tests.sh
+  use_fake_gh happy
+  run_script preflight.sh 6
+  assert_key "$OUT" CMD_TEST ""
+}
+
+# A runner at the top is the repository's entry point, so it wins outright and the search
+# below it never happens - not even for a tracked one.
+test_preflight_root_harness_wins_over_nested_ones() {
+  local repo
+  repo=$(init_repo)
+  cd "$repo"
+  mkdir -p tests plugins/foo/tests
+  printf '#!/usr/bin/env bash\n' >tests/run-tests.sh
+  printf '#!/usr/bin/env bash\n' >plugins/foo/tests/run-tests.sh
+  git add plugins/foo/tests/run-tests.sh
+  use_fake_gh happy
+  run_script preflight.sh 6
+  assert_key "$OUT" CMD_TEST "bash tests/run-tests.sh"
+}
+
+# Regression: the config path was the last cwd-relative read left in the script, and it
+# outranks auto-detect - so a run from a subdirectory found no config, silently swapped
+# the pinned test command for a guess, and lost the pinned base branch with it. The
+# package.json is here so a regression shows up as `npm test`, not as an empty value.
+test_preflight_reads_the_config_from_a_subdirectory() {
+  local repo
+  repo=$(init_repo)
+  cd "$repo"
+  mkdir -p .claude sub
+  printf -- '---\nbase_branch: dev\ntest_cmd: make ci\n---\n' >.claude/issue-to-pr.local.md
+  printf '%s\n' '{ "scripts": { "test": "jest" } }' >package.json
+  cd sub
+  use_fake_gh happy
+  run_script preflight.sh 6
+  assert_key "$OUT" CONFIG_PRESENT true
+  assert_key "$OUT" CMD_TEST "make ci"
+  assert_key "$OUT" CMD_SOURCE_TEST config
+  assert_key "$OUT" BASE dev
+}
+
+# run-gates.sh hands the command to `bash -c`, so a project directory with a space in
+# its name has to come back as one argument or the gate is permanently red on a repo
+# with a perfectly good suite. Asserted by RUNNING it rather than by matching bash's
+# escaping style.
+test_preflight_nested_harness_survives_a_space_in_the_path() {
+  local repo cmd
+  repo=$(init_repo)
+  cd "$repo"
+  mkdir -p "my proj/tests"
+  printf '#!/usr/bin/env bash\nexit 0\n' >"my proj/tests/run-tests.sh"
+  git add "my proj/tests/run-tests.sh"
+  use_fake_gh happy
+  run_script preflight.sh 6
+  assert_contains "$OUT" "my proj/tests/run-tests.sh"
+  cmd=$(printf '%s\n' "$OUT" | grep -m1 '^CMD_TEST=' | sed 's/^CMD_TEST=//')
+  if ! bash -c "$cmd"; then fail "the detected command does not run as one path: $cmd"; fi
+}
+
+# An explicit --config is the caller's instruction and stays relative to the caller; only
+# the default path is re-rooted. Re-rooting both would hand a caller standing in a
+# subdirectory with a real ./custom.md the auto-detected commands instead of their own.
+test_preflight_explicit_relative_config_stays_relative_to_the_caller() {
+  local repo
+  repo=$(init_repo)
+  cd "$repo"
+  mkdir -p sub
+  printf -- '---\ntest_cmd: from sub\n---\n' >sub/custom.md
+  printf -- '---\ntest_cmd: from root\n---\n' >custom.md
+  cd sub
+  use_fake_gh happy
+  run_script preflight.sh 6 --config custom.md
+  assert_key "$OUT" CMD_TEST "from sub"
+}
+
+# Regression: a `check:`-only Makefile (the GNU spelling) reported `make typecheck`,
+# which make refuses for want of such a rule - a red gate on a healthy repository, with
+# nothing to tell the model the command had been invented rather than read.
+test_preflight_makefile_check_target_is_reported_as_itself() {
+  local repo
+  repo=$(init_repo)
+  cd "$repo"
+  printf 'check:\n\t@true\n' >Makefile
+  use_fake_gh happy
+  run_script preflight.sh 6
+  assert_key "$OUT" CMD_TYPECHECK "make check"
+}
+
+# Regression: the search read the working tree, so a gitignored scratch project's runner
+# was taken as a suite of this repository. It is absent from the worktree the gates run
+# in, so the gate died at 127 - and sorting first, it also kept the real suite from
+# running. It is not tracked, so it is not a candidate now, and the real one still is.
+test_preflight_ignores_a_gitignored_project() {
+  local repo
+  repo=$(init_repo)
+  cd "$repo"
+  printf 'aaa-sandbox/\n' >.gitignore
+  mkdir -p aaa-sandbox/tests plugins/real/tests
+  printf '#!/usr/bin/env bash\n' >aaa-sandbox/tests/run-tests.sh
+  printf '#!/usr/bin/env bash\n' >plugins/real/tests/run-tests.sh
+  git add plugins/real/tests/run-tests.sh
+  use_fake_gh happy
+  run_script preflight.sh 6
+  assert_not_contains "$OUT" aaa-sandbox
+  assert_key "$OUT" CMD_TEST 'bash "plugins/real/tests/run-tests.sh"'
+}
+
+# Regression: anchoring the probes to "whatever tree cwd is in" meant that starting a run
+# for issue 9 from issue 5's worktree gated issue 9 on a project that exists only on
+# issue 5's branch - while the same script reported issue 9's own worktree as absent.
+test_preflight_never_probes_a_foreign_worktree() {
+  local repo other
+  repo=$(init_repo)
+  cd "$repo"
+  mkdir -p tests
+  printf '#!/usr/bin/env bash\n' >tests/run-tests.sh
+  git -C "$repo" worktree add "$TEST_TMPDIR/repo-worktrees/issue-5" -b feat/issue-5-x HEAD >/dev/null 2>&1
+  other="$TEST_TMPDIR/repo-worktrees/issue-5"
+  mkdir -p "$other/newpkg/tests"
+  printf '#!/usr/bin/env bash\n' >"$other/newpkg/tests/run-tests.sh"
+  cd "$other"
+  use_fake_gh happy
+  run_script preflight.sh 9
+  assert_key "$OUT" CMD_TEST "bash tests/run-tests.sh"
+  assert_not_contains "$OUT" newpkg
+}
+
 test_preflight_worktree_resumable() {
   local repo
   repo=$(init_repo)

--- a/plugins/issue-to-pr/tests/contract/test_preflight.sh
+++ b/plugins/issue-to-pr/tests/contract/test_preflight.sh
@@ -258,7 +258,7 @@ test_preflight_detects_package_json_from_a_subdirectory() {
 }
 
 # A plugin or package monorepo keeps its runner under the project, not at the top. The
-# path is quoted because run-gates.sh hands the value to `bash -c`.
+# path is emitted bare, and only when nothing in it could change how a shell reads it.
 test_preflight_finds_a_nested_harness() {
   local repo
   repo=$(init_repo)
@@ -268,7 +268,7 @@ test_preflight_finds_a_nested_harness() {
   git add plugins/foo/tests/run-tests.sh
   use_fake_gh happy
   run_script preflight.sh 6
-  assert_key "$OUT" CMD_TEST 'bash "plugins/foo/tests/run-tests.sh"'
+  assert_key "$OUT" CMD_TEST "bash plugins/foo/tests/run-tests.sh"
   assert_key "$OUT" CMD_SOURCE_TEST plugins/foo/tests/run-tests.sh
 }
 
@@ -339,22 +339,37 @@ test_preflight_reads_the_config_from_a_subdirectory() {
   assert_key "$OUT" BASE dev
 }
 
-# run-gates.sh hands the command to `bash -c`, so a project directory with a space in
-# its name has to come back as one argument or the gate is permanently red on a repo
-# with a perfectly good suite. Asserted by RUNNING it rather than by matching bash's
-# escaping style.
-test_preflight_nested_harness_survives_a_space_in_the_path() {
+# SECURITY. The detected command is evaluated by `bash -c` in run-gates.sh, so a tracked
+# directory named `$(...)` used to execute at gate time on any repository merely cloned
+# and taken through Step 0. Reproduced against the double-quoted form this replaced.
+test_preflight_nested_harness_path_cannot_inject_a_command() {
   local repo cmd
   repo=$(init_repo)
   cd "$repo"
+  mkdir -p 'plugins/$(touch PWNED)/tests'
+  printf '#!/usr/bin/env bash\n' >'plugins/$(touch PWNED)/tests/run-tests.sh'
+  git add 'plugins/$(touch PWNED)/tests/run-tests.sh'
+  use_fake_gh happy
+  run_script preflight.sh 6
+  assert_key "$OUT" CMD_TEST ""
+  cmd=$(printf '%s\n' "$OUT" | grep -m1 '^CMD_TEST=' | sed 's/^CMD_TEST=//')
+  bash -c "$cmd" >/dev/null 2>&1
+  if [ -e PWNED ]; then fail "the detected command executed a substitution from a path"; fi
+}
+
+# A path that needs quoting to be one argument is left undetected instead. The value is
+# evaluated twice (bash -c, and Step 6's --gate test='<cmd>' wrapper), so no quoting
+# scheme survives both; not detecting is the honest outcome and pin-config names it.
+test_preflight_nested_harness_with_a_space_is_not_used() {
+  local repo
+  repo=$(init_repo)
+  cd "$repo"
   mkdir -p "my proj/tests"
-  printf '#!/usr/bin/env bash\nexit 0\n' >"my proj/tests/run-tests.sh"
+  printf '#!/usr/bin/env bash\n' >"my proj/tests/run-tests.sh"
   git add "my proj/tests/run-tests.sh"
   use_fake_gh happy
   run_script preflight.sh 6
-  assert_contains "$OUT" "my proj/tests/run-tests.sh"
-  cmd=$(printf '%s\n' "$OUT" | grep -m1 '^CMD_TEST=' | sed 's/^CMD_TEST=//')
-  if ! bash -c "$cmd"; then fail "the detected command does not run as one path: $cmd"; fi
+  assert_key "$OUT" CMD_TEST ""
 }
 
 # An explicit --config is the caller's instruction and stays relative to the caller; only
@@ -402,7 +417,7 @@ test_preflight_ignores_a_gitignored_project() {
   use_fake_gh happy
   run_script preflight.sh 6
   assert_not_contains "$OUT" aaa-sandbox
-  assert_key "$OUT" CMD_TEST 'bash "plugins/real/tests/run-tests.sh"'
+  assert_key "$OUT" CMD_TEST "bash plugins/real/tests/run-tests.sh"
 }
 
 # Regression: anchoring the probes to "whatever tree cwd is in" meant that starting a run


### PR DESCRIPTION
Gate-command detection tested `package.json`, `Cargo.toml`, `go.mod`, `Makefile` and `tests/run-tests.sh` relative to whatever directory preflight was invoked from, while repo identity and worktree state resolved against the repository. Run it from a subdirectory and Step 0 reported no test command for a project that plainly has one.

## What changed

Every Step-0 probe now resolves against the main checkout, so the answer no longer depends on where you started.

The config turned out to be the same bug in the source that **outranks** auto-detect, and this is the part worth reading twice: a run started from a subdirectory found no config at all and silently replaced the pinned test command, base branch and board with whatever detection guessed, reporting `CONFIG_PRESENT=false` and nothing else. Only the default path is re-rooted; a relative `--config` you pass yourself is your instruction and stays relative to you.

A repository whose only runner sits inside a project rather than at the top is now found, provided there is exactly one of them and it is tracked. This repository is that case: `plugins/issue-to-pr/tests/run-tests.sh` is detected identically from the root and from any subdirectory, where before the run needed the command pinned by hand.

Smaller things in the same path: a `check:`-only Makefile reports `make check` instead of a `make typecheck` no rule defines and the run then stops on; `resolve_under()` moves into `lib/common.sh` where `worktree.sh`'s `--salvage-to` already needed it, and recognises `\\server\share` as absolute; and a bare-repo-plus-worktrees layout falls back to the tree in hand, since `git worktree list` puts the bare directory first and it holds neither the config nor a project to probe.

## What was deliberately left out

Assembling one test command from several project runners. It was built, reviewed three times, and taken back out. Step 0 probes the current checkout while the gates run in a worktree that Step 1 cuts from `origin/<base>` afterwards, so any per-project enumeration can disagree with the tree actually under test, and one stale link in an `&&` chain either hides a red suite or kills the whole command. Three reproduced ways that went wrong, the constraints they imply, and the two smaller quoting traps are written up in #23 for whoever takes it.

Two or more runners are therefore ambiguous on purpose: no test command is reported, Step 6 degrades loudly, and `pin-config.sh` is how you say which one.

## Decisions made autonomously

- The tier came out `trivial`, computed from the issue text alone. Raised to `standard` (mini-design, `medium` review) because the nested search is a behaviour change with a false-green hazard, and the ratchet then took the review to `high` and `max` as passes kept confirming bugs.
- The probes anchor to the main checkout rather than the tree you are standing in. Anchoring them to the tree the gates will use cannot be done at Step 0, which runs before that worktree exists.
- The config keeps its own anchor for a different reason: it is normally untracked, so a worktree has no copy. A repository that commits it is read from the main checkout too, which means a branch changing the config is gated by the base's version. A wart, and noted as one.
- The top-level probe still accepts an untracked runner, which is its long-standing behaviour, while the nested search requires tracked. Untracked-and-nested is precisely what is missing from the worktree the gates run in.

## Tests

Fourteen new, each red against the old code: detection and config from a subdirectory, a single nested runner, ambiguity when there are two, an untracked or gitignored one being skipped, a space in the path asserted by running the command rather than by matching an escaping style, a foreign worktree never being probed, `make check`, an explicit relative `--config`, and `resolve_under` over five absolute forms. Full suite green: shellcheck clean over 14 files, 209/209 contract tests.

Closes #17


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved automatic detection of test runners and Makefile-based check commands.
  * Added support for nested project test harnesses, repository-root checks, and multiple path formats.

* **Bug Fixes**
  * Fixed configuration and gate detection across directories and worktrees.
  * Improved handling of ambiguous, ignored, and unrelated test runners.
  * Corrected path resolution for relative and absolute locations.

* **Documentation**
  * Clarified command detection, configuration precedence, and repository-root requirements.
  * Added changelog details for version 2.4.1.

* **Chores**
  * Updated the plugin version to 2.4.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->