### PR TITLE
refactor(issue-to-pr): make tune try the cheap fixes before adding machinery (v2.6.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -130,7 +130,7 @@
     {
       "name": "issue-to-pr",
       "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp files; the issue auto-closes on merge and the board card advances as work moves.",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "author": {
         "name": "Dmitry Yuhanov"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -130,7 +130,7 @@
     {
       "name": "issue-to-pr",
       "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp files; the issue auto-closes on merge and the board card advances as work moves.",
-      "version": "2.5.1",
+      "version": "2.6.0",
       "author": {
         "name": "Dmitry Yuhanov"
       },

--- a/plugins/issue-to-pr/.claude-plugin/plugin.json
+++ b/plugins/issue-to-pr/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "issue-to-pr",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp files; the issue auto-closes on merge and the board card advances as work moves.",
   "author": {
     "name": "Dmitry Yuhanov"

--- a/plugins/issue-to-pr/.claude-plugin/plugin.json
+++ b/plugins/issue-to-pr/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "issue-to-pr",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp files; the issue auto-closes on merge and the board card advances as work moves.",
   "author": {
     "name": "Dmitry Yuhanov"

--- a/plugins/issue-to-pr/CHANGELOG.md
+++ b/plugins/issue-to-pr/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the **issue-to-pr** plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.6.0] - 2026-08-20
+
+### Changed
+- `/issue-to-pr:tune` now tries the cheap answers first: delete the behaviour, ask for explicit input, clarify the wording, and only then add another script or test. The old rule preferred a mechanical stop every time, which is how the plugin came to carry more shell than prose
+
 ## [2.5.1] - 2026-08-20
 
 ### Changed

--- a/plugins/issue-to-pr/CHANGELOG.md
+++ b/plugins/issue-to-pr/CHANGELOG.md
@@ -5,10 +5,10 @@ All notable changes to the **issue-to-pr** plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [2.6.0] - 2026-08-20
+## [2.6.1] - 2026-08-20
 
 ### Changed
-- `/issue-to-pr:tune` now tries the cheap answers first: delete the behaviour, ask for explicit input, clarify the wording, and only then add another script or test. The old rule preferred a mechanical stop every time, which is how the plugin came to carry more shell than prose
+- Propose the cheapest fix first when tuning friction: deletion, explicit input, or clearer wording before another script or test
 
 ## [2.5.1] - 2026-08-20
 

--- a/plugins/issue-to-pr/skills/tune/SKILL.md
+++ b/plugins/issue-to-pr/skills/tune/SKILL.md
@@ -28,16 +28,14 @@ model. This skill batches that evidence into real changes.
 3. **Propose the cheapest fix that holds.** For each cluster work down this ladder and
    stop at the first rung that answers the friction, quoting the lines as evidence. A
    change with no evidence line does not belong here.
-   1. **Delete the behaviour.** Friction is often a feature nobody needs, defending itself.
+   1. **Delete the behaviour** when nothing depends on it.
    2. **Require explicit input** where the pipeline was guessing.
    3. **Clarify the prose** so the model has what it needs to decide.
-   4. **Add enforcement** — an exit code, a hook, a test — and only at a boundary where
-      being wrong costs something irreversible.
+   4. **Add enforcement**: an exit code, a hook, a test. Only at a boundary where being
+      wrong costs something irreversible.
 
-   Rung 4 used to be the default here ("prefer a mechanical stop over prose that asks the
-   model to remember"), and it is how this plugin came to carry more shell and fixtures
-   than prose, each new script arriving with its own defects. Reach for it last, and say
-   in the proposal why the rungs above it do not answer the friction.
+   Rung 4 is the expensive one, since it adds code to maintain and test. Reach for it
+   last, and say in the proposal why the rungs above do not answer the friction.
 4. **Confirm, then apply.** Show the batched proposal and ask for a go-ahead. On
    approval, make the edits (bump the plugin version + changelog per repo rules),
    run the gates (`tests/run-tests.sh`), and — if the changed area is behavioral —

--- a/plugins/issue-to-pr/skills/tune/SKILL.md
+++ b/plugins/issue-to-pr/skills/tune/SKILL.md
@@ -25,10 +25,19 @@ model. This skill batches that evidence into real changes.
    absent or empty, say so and stop — nothing to tune.
 2. **Cluster.** Group the lines by root cause, not by surface symptom. Three notes
    about the same confusing exit code are one fix, not three.
-3. **Propose.** For each cluster, propose the smallest concrete change to the SKILL,
-   a script, or a reference — quoting the friction lines as evidence. A change with
-   no evidence line does not belong here. Prefer edits that make a stop mechanical
-   (an exit code / a test) over prose that asks the model to remember.
+3. **Propose the cheapest fix that holds.** For each cluster work down this ladder and
+   stop at the first rung that answers the friction, quoting the lines as evidence. A
+   change with no evidence line does not belong here.
+   1. **Delete the behaviour.** Friction is often a feature nobody needs, defending itself.
+   2. **Require explicit input** where the pipeline was guessing.
+   3. **Clarify the prose** so the model has what it needs to decide.
+   4. **Add enforcement** — an exit code, a hook, a test — and only at a boundary where
+      being wrong costs something irreversible.
+
+   Rung 4 used to be the default here ("prefer a mechanical stop over prose that asks the
+   model to remember"), and it is how this plugin came to carry more shell and fixtures
+   than prose, each new script arriving with its own defects. Reach for it last, and say
+   in the proposal why the rungs above it do not answer the friction.
 4. **Confirm, then apply.** Show the batched proposal and ask for a go-ahead. On
    approval, make the edits (bump the plugin version + changelog per repo rules),
    run the gates (`tests/run-tests.sh`), and — if the changed area is behavioral —


### PR DESCRIPTION
`skills/tune/SKILL.md` told the tuner to prefer a mechanical stop over prose that asks the model to remember. That single line is the reason this plugin carries 2532 lines of bash with 2644 lines of tests behind them, against about 790 lines of prose: every piece of friction a run reported was converted into another script, and each new script arrived with defects of its own.

It is replaced by a ladder that stops at the first rung that actually answers the friction:

1. delete the behaviour, because friction is often a feature nobody needs defending itself
2. require explicit input where the pipeline was guessing
3. clarify the prose so the model has what it needs to decide
4. add enforcement, and only at a boundary where being wrong costs something irreversible

The paragraph underneath records why the rule changed. Without it the old default returns at the first painful iteration, which is exactly how it got there.

This lands before the other cleanups in the same series (#27 through #32), otherwise they grow back.

## Tests

None added. The change is fourteen lines of prose in one file, and the ladder's own first rungs say not to reach for a fixture to hold prose in place. Full suite still green: shellcheck clean over 14 files, 231/231.

Closes #26


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved tuning recommendations to prioritize removing unnecessary behavior, requiring explicit input, and clarifying wording before adding scripts or tests.
  - Recommendations now explain why simpler solutions are insufficient before suggesting mechanical enforcement.

- **Documentation**
  - Updated release notes for version 2.6.1.
  - Updated plugin version information to 2.6.1.
  - Clarified guidance for selecting evidence-backed tuning proposals and applying enforcement only when simpler approaches do not resolve the issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->