### PR TITLE
Prune the gate receipt on cleanup

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -75,7 +75,7 @@
     {
       "name": "learning-guide",
       "description": "Generate a single-file, interactive HTML learning guide for any artifact — codebase, planning session, refactor plan, or generic input — via an analyze → render flow with a JSON tour-spec contract",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "author": {
         "name": "Dmitry Yuhanov"
       },
@@ -130,7 +130,7 @@
     {
       "name": "issue-to-pr",
       "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp files; the issue auto-closes on merge and the board card advances as work moves.",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "author": {
         "name": "Dmitry Yuhanov"
       },

--- a/plugins/issue-to-pr/.claude-plugin/plugin.json
+++ b/plugins/issue-to-pr/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "issue-to-pr",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp files; the issue auto-closes on merge and the board card advances as work moves.",
   "author": {
     "name": "Dmitry Yuhanov"

--- a/plugins/issue-to-pr/CHANGELOG.md
+++ b/plugins/issue-to-pr/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the **issue-to-pr** plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [3.0.1] - 2026-08-22
+
+### Fixed
+- Cleanup now removes the branch's gate receipt, so the plugin's state directory stops growing after every merge
+
 ## [3.0.0] - 2026-08-21
 
 ### Removed

--- a/plugins/issue-to-pr/scripts/worktree.sh
+++ b/plugins/issue-to-pr/scripts/worktree.sh
@@ -466,6 +466,11 @@ cmd_cleanup() {
     deleted_remote=true
   fi
 
+  # The branch is gone, so its gate receipt can never match a head again. Nothing
+  # else prunes them since the approval sweep went with the marker in 3.0.0, and a
+  # state directory that only ever grows is how the old markers piled up.
+  rm -f "$(receipt_path "$root" "$branch")" 2>/dev/null
+
   emit REMOVED "$REMOVED"
   emit DELETED_LOCAL "$deleted_local"
   emit DELETED_REMOTE "$deleted_remote"

--- a/plugins/issue-to-pr/tests/contract/test_worktree.sh
+++ b/plugins/issue-to-pr/tests/contract/test_worktree.sh
@@ -494,3 +494,17 @@ test_wt_merge_unreadable_head_stops() {
   if printf '%s' "$(gh_log)" | grep -q 'pr merge'; then fail "merged without knowing the head"; fi
 }
 
+# 3.0.1: with the approval sweep gone, cleanup is the only thing that prunes state.
+# A receipt for a deleted branch can never match a head again, so leaving it behind
+# is how the old markers piled up.
+test_wt_cleanup_prunes_the_gate_receipt() {
+  local repo wt; repo=$(mk_repo); wt=$(mk_worktree "$repo" feat/issue-6-x); cd "$repo"
+  write_receipt "$repo" feat/issue-6-x "$SHA_OK"
+  use_fake_gh pr-merged
+  run_script worktree.sh cleanup 6 --branch feat/issue-6-x
+  assert_rc 0
+  if [ -e "$repo/.claude/issue-to-pr/gates-feat-issue-6-x.json" ]; then
+    fail "cleanup left the gate receipt behind"
+  fi
+}
+


### PR DESCRIPTION
## What

`worktree.sh cleanup` deletes the branch's gate receipt, the way it used to delete the approval marker.

## Why

3.0.0 removed the marker and, with it, the preflight sweep that pruned the state directory. Nothing took over. A receipt names the head it was written for, so once the branch is deleted it can never match anything again: it is dead weight that accumulates one file per merged issue. That is exactly how the markers piled up before there was a sweep.

## Gate

`bash plugins/issue-to-pr/tests/run-tests.sh` → `tests: 141  passed: 141  failed: 0  ALL GREEN`, shellcheck clean. One new test: cleanup leaves no receipt behind.
