### PR TITLE
feat(issue-to-pr): ponytail shapes the design, not just the last gate (v4.1.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -130,7 +130,7 @@
     {
       "name": "issue-to-pr",
       "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp files; the issue auto-closes on merge and the board card advances as work moves.",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "author": {
         "name": "Dmitry Yuhanov"
       },

--- a/plugins/issue-to-pr/.claude-plugin/plugin.json
+++ b/plugins/issue-to-pr/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "issue-to-pr",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp files; the issue auto-closes on merge and the board card advances as work moves.",
   "author": {
     "name": "Dmitry Yuhanov"

--- a/plugins/issue-to-pr/CHANGELOG.md
+++ b/plugins/issue-to-pr/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the **issue-to-pr** plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [4.1.0] - 2026-08-25
+
+### Changed
+- Set ponytail's lazy mode before the design instead of after the code, so it prevents over-engineering rather than reporting it
+
+### Fixed
+- Point the final over-engineering review at the work in progress; it was diffing two commits and seeing nothing
+
 ## [4.0.0] - 2026-08-22
 
 ### Changed

--- a/plugins/issue-to-pr/skills/run/SKILL.md
+++ b/plugins/issue-to-pr/skills/run/SKILL.md
@@ -76,7 +76,8 @@ a full 0–12 run.
 `Explore` subagent handed an explicit question list. Either way you get back a ≤150-line summary
 citing `path:line`; the raw file reads stay in its context, not yours.
 
-**4. Design** (tier routes it). Complex+: `Workflow({scriptPath:
+**4. Design** (tier routes it). **Ponytail installed → `/ponytail:ponytail full` first**, ledgered:
+design and implementation then run under the ladder. Complex+: `Workflow({scriptPath:
 "S/../workflows/design-panel.js", args:{issue,title,contextFiles,constraints,openQuestions}})`
 → `design_md` (→ `<RUN_DIR>/design.md`) + rejected alternatives + open questions. Accept
 only if `received_issue` matches `<N>` **and** `design_md` is non-empty **and**
@@ -106,7 +107,9 @@ subagents critique the diff at the tier's level, ≤ tier's max passes. `/code-r
 <level> --fix` is preferred only when it's actually callable — most copies ship
 `disable-model-invocation`, which blocks a skill run from invoking it at all (`R/companions.md`).
 Run them in the **foreground**, never while gates run — a reviewer editing the shared worktree
-mid-gate produces a phantom red. **Security overlay:** `S/changed-paths.sh --base "<BASE>"` lists
+mid-gate produces a phantom red. Ponytail rides in with them: their prompt says it governs how a
+confirmed bug gets fixed, never whether it counts as one.
+**Security overlay:** `S/changed-paths.sh --base "<BASE>"` lists
 what this branch touched (committed, uncommitted, untracked); you decide from the diff whether
 it reaches auth, crypto, secrets, sessions, payments or migrations, and add one
 `/security-review` if it does. `R/tier-matrix.md` holds the floor you cannot argue down. Track `confirmed_bugs_this_pass`/`gate_fail_streak` in metrics;
@@ -115,9 +118,11 @@ after each fix.
 
 **8. Re-gates + ponytail.** Re-run `run-gates.sh` (all green). If commands you worked out
 yourself passed and config lacks them, **print the frontmatter block** for `<CONFIG_PATH>` in
-the report for the user to paste. Never write it yourself: the file can be tracked and shared. **Final gate, when ponytail is installed:**
-`/ponytail:ponytail ultra`, then `/ponytail:ponytail-review` over `git diff <BASE>...HEAD`. Apply
-the cuts you agree with and re-run gates; answer the rest in one line each in the report.
+the report for the user to paste. Never write it yourself: the file can be tracked and shared.
+**Final gate, when ponytail is installed:** `/ponytail:ponytail-review` over `git diff <BASE>`
+(two dots — Step 9 has not committed yet, so `<BASE>...HEAD` compares two commits and shows an
+empty diff here) plus any untracked file `S/changed-paths.sh --base "<BASE>"` names. Apply the
+cuts you agree with and re-run gates; answer the rest in one line each in the report.
 
 **9. Commit + PR.** `git add <explicit paths>`, conventional subjects; `git push -u origin
 <branch>`. **Re-run `run-gates.sh` on the commit**: it leaves the receipt Step 11 checks, and a

--- a/plugins/issue-to-pr/skills/run/references/companions.md
+++ b/plugins/issue-to-pr/skills/run/references/companions.md
@@ -14,7 +14,8 @@ companion silently degrade quality without saying so.
 | Codebase research (Step 3, complex+) | forked `research` sub-skill (isolated subagent → ≤150-line cited summary); `/deep-research` for external topics | A focused inline exploration distilled to a short summary. |
 | Design generation (Step 4, complex+) | `workflows/design-panel.js` (3 proposers → 2 adversarial critics → opus judge), with `/cross-review` critiquing the produced `design_md` | Inline self-review chain: draft, adversarially self-critique against the code, revise. |
 | Humanizing human-facing text (Step 9–10) | `humanizer` | Self-edit the PR body / report to drop AI-tell phrasing; flag that a humanizer pass would help. |
-| Final over-engineering gate (Step 8) | `ponytail:ponytail ultra` to set the mode, then `ponytail:ponytail-review` over the run's diff | Re-read the diff hunting only for what to delete: reinvented stdlib, one-caller abstractions, config nobody sets, flags nobody passes. |
+| Lazy design and build (Steps 4–5) | `ponytail:ponytail full`, set once before the design | Design and build against the same ladder by hand: does this need to exist, does the stdlib or the platform already do it, can it be one line. |
+| Final over-engineering gate (Step 8) | `ponytail:ponytail-review` over the run's diff | Re-read the diff hunting only for what to delete: reinvented stdlib, one-caller abstractions, config nobody sets, flags nobody passes. |
 | Diff review loop (Step 7) | `/code-review` — only if callable (see note) | Independent adversarial review subagents (2–3 reviewers) critique the diff for correctness, reuse, and regressions; iterate. This is the default in practice. |
 
 ## Install hints (same marketplace)
@@ -35,6 +36,15 @@ the model's own SlashCommand tool cannot invoke it, even from inside a skill run
 Step 7 calling it mid-pipeline is a no-op, not a degraded case: it never fires and the
 inline fallback runs instead. Don't treat "installed" as "callable" — the fallback is the
 realistic default, not a rare miss.
+
+## Note: ponytail carries itself, and it reaches the reviewers too
+
+Ponytail ships a `SubagentStart` hook that injects its ruleset into every subagent from the
+persisted mode, so setting it once at Step 4 is the whole wiring: implementation subagents
+inherit it and the pipeline passes nothing along. The Step 7 adversarial reviewers inherit it
+too, though their job is correctness and lazy mode pulls toward deletion — their prompt says
+which is which, and `PONYTAIL_SUBAGENT_MATCHER` scopes the injection by agent type for anyone
+who wants a harder fence.
 
 These are recommendations, not requirements — the skill checks availability at the relevant
 step and proceeds either way.

--- a/plugins/issue-to-pr/tests/contract/test_skill-lint.sh
+++ b/plugins/issue-to-pr/tests/contract/test_skill-lint.sh
@@ -74,3 +74,34 @@ test_skill_keeps_merge_gate_rule() {
   c=$(cat "$(skill_md)")
   assert_contains "$c" "main session"
 }
+
+# Ponytail used to enter at Step 8, after the code was written, and its first act was to
+# switch the session to `ultra`. Both halves were wrong: the over-engineering it hunts was
+# designed in at Step 4 and typed at Step 5, and `ponytail-review` is a separate skill that
+# never reads the session mode, so the switch changed nothing. The mode now goes on at Step 4,
+# and ponytail's own SubagentStart hook carries it into every implementation subagent.
+test_skill_sets_ponytail_mode_at_design_not_at_the_final_gate() {
+  local c
+  c=$(cat "$(skill_md)")
+  # Placement, not just presence: a `full` that drifted down to Step 8 would still satisfy a
+  # bare "contains" check while setting the mode after the design it was meant to shape.
+  printf '%s\n' "$c" | grep '^\*\*4\. Design\*\*' | grep -q '/ponytail:ponytail full' ||
+    fail "Step 4's own line must be where ponytail's mode is set"
+  assert_not_contains "$c" "ponytail:ponytail ultra" \
+    "the final gate must not switch modes; ponytail-review ignores the session mode"
+}
+
+# `git diff <BASE>...HEAD` compares two commits, and Step 8 runs before Step 9 commits, so on a
+# fresh branch it showed the ponytail gate an empty diff while the whole run sat uncommitted in
+# the worktree. The gate reviewed nothing and reported clean.
+test_skill_final_review_reads_the_uncommitted_worktree() {
+  local c
+  c=$(cat "$(skill_md)")
+  assert_contains "$c" 'ponytail-review` over `git diff <BASE>`' \
+    "the final review diffs the base against the working tree, not one commit against another"
+  # Two dots still miss a file git has never seen, and a run that adds one is the common case.
+  # Anchored on "untracked file" because the bare command string also appears in Step 7, where
+  # it would satisfy a looser assertion no matter what Step 8 said.
+  assert_contains "$c" 'untracked file `S/changed-paths.sh --base "<BASE>"` names' \
+    "the final review is handed the untracked files too"
+}


### PR DESCRIPTION
## What changed

Ponytail entered the pipeline at Step 8, after the code was written, and its first act was to switch the session to `ultra`. Both halves were wrong. The over-engineering it hunts was designed in at Step 4 and typed at Step 5, so by Step 8 it is reviewing damage it could have prevented. And `ponytail-review` is a separate skill that never reads the session mode, so the switch changed nothing at all.

The mode now goes on at Step 4, before the design is written, and the run ledgers it. Step 5 needed no new instruction: ponytail ships a `SubagentStart` hook that injects its ruleset into every subagent from the persisted mode, so implementation subagents inherit it and the pipeline passes nothing along. Step 8 keeps `ponytail-review` and drops the mode switch.

Step 7 gains one caveat, because the same hook reaches the adversarial reviewers. Their job is correctness and lazy mode pulls toward deletion, so their prompt now says which is which: ponytail governs how a confirmed bug gets fixed, never whether it counts as a bug. For anyone who wants a harder fence, `PONYTAIL_SUBAGENT_MATCHER` scopes the injection by agent type, and `companions.md` says so.

## A bug the review found

CodeRabbit flagged the line this change was already touching, and it was right. Step 8 told the model to review `git diff <BASE>...HEAD`, but Step 9 is what commits, so on a fresh branch HEAD is still the base and the three-dot form compares a commit with itself. Verified in the worktree: with the run uncommitted, `git diff main...main --name-only` lists zero files while the tree holds a modified file and an untracked one.

So Step 8 has been handing the ponytail gate an empty diff since v2.7.0, and the gate reported clean every time. Runs only looked right because the model passed the diff by hand instead of running the documented command, which is exactly what a spine instruction must not depend on.

Step 8 now reviews `git diff <BASE>` plus whatever untracked files `changed-paths.sh` names, and a contract test pins the command. Two other findings from the same review are in: the mode-setting assertion greps Step 4's own line, so a command that drifts to another step fails instead of passing a bare presence check, and the changelog entry is in imperative mood.

## Mini-design

Three prose edits to the spine, plus one table row and one note in `companions.md`. No script changed, because nothing needed wiring: the feature itself is one mode switch at the right moment, and the hook that carries it already exists upstream.

Rejected: passing the ponytail ruleset into subagent prompts by hand. It duplicates what the `SubagentStart` hook already does, and it would go stale the next time ponytail changes its ladder.

Rejected: keeping a mode switch at Step 8, set to `full` instead of `ultra`. It still buys nothing, because the review skill reads no mode, and it costs a line of a 180-line budget.

## Decisions made autonomously

- Tier `standard`. A prose change to the spine with acceptance criteria across two files and a lint test, and the rubric answers `standard` whenever the signals disagree.
- The review pass ran inline rather than through review subagents, on a standing session instruction not to spawn agents. That is thinner than the tier normally gets, and it is why CodeRabbit caught a Major finding the inline pass missed.
- `full`, not `ultra`, for the design mode. `ultra` is an intensity the issue did not ask for, and `full` is ponytail's own documented default.
- The `SubagentStart` behaviour is documented in `companions.md` rather than the spine, which sits at 179 of its 180 lines.
- The branch is one commit rather than two. The pre-commit hook compares the staged version against `HEAD`, so a follow-up commit on the same branch would have needed a version 4.1.0 never shipped under.

## Test status

`bash plugins/issue-to-pr/tests/run-tests.sh`: 144 passed, 0 failed, including both new contract tests. Green before the ponytail cuts, after them, and again after the review fixes.

Closes #43


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the issue-to-PR workflow so Ponytail can guide design, implementation, adversarial review, and final validation.
  * Added support for automatically applying Ponytail’s configured mode during implementation and review steps.

* **Documentation**
  * Updated workflow guidance and companion documentation to reflect the integrated Ponytail process.
  * Added a changelog entry for version 4.1.0.

* **Tests**
  * Added validation to ensure the workflow uses the updated Ponytail modes and reviews uncommitted work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->