### PR TITLE
feat(issue-to-pr): Step 8 becomes a two-pass simplification gate (v4.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -130,7 +130,7 @@
     {
       "name": "issue-to-pr",
       "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp files; the issue auto-closes on merge and the board card advances as work moves.",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "author": {
         "name": "Dmitry Yuhanov"
       },

--- a/plugins/issue-to-pr/.claude-plugin/plugin.json
+++ b/plugins/issue-to-pr/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "issue-to-pr",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp files; the issue auto-closes on merge and the board card advances as work moves.",
   "author": {
     "name": "Dmitry Yuhanov"

--- a/plugins/issue-to-pr/CHANGELOG.md
+++ b/plugins/issue-to-pr/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the **issue-to-pr** plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [4.2.0] - 2026-08-25
+
+### Changed
+- Run the pre-PR gate as two lenses over two passes, deletion and simplification, so a cut that broke something gets caught by the next pass instead of by nobody
+
+### Fixed
+- Review the diff with the reviewer Claude Code ships rather than an inline stand-in; the pipeline had been avoiding it over a caveat that only applies to plugin commands of the same name
+
 ## [4.1.0] - 2026-08-25
 
 ### Changed

--- a/plugins/issue-to-pr/README.md
+++ b/plugins/issue-to-pr/README.md
@@ -77,11 +77,17 @@ again, but the next merge asks for one more gate run before it will land.
 
 ### Companion skills (optional)
 
+Two of the sharpest tools need no install: Claude Code's own `code-review` reviews the
+diff at Step 7, and its `simplify` is one of the two lenses of the Step 8 gate. The CLI
+registers both, so no marketplace is involved. (An earlier version of this README claimed
+the pipeline could not reach `code-review` because copies ship `disable-model-invocation`.
+That is a plugin command of the same name, not the built-in skill, and the claim cost
+Step 7 a real reviewer for several releases.)
+
 Optional companions that sharpen specific steps: `superpowers:*`, `/deep-research`,
-`/cross-review` (from `codex-collaboration`), `humanizer`, and `/code-review`. Each is
-used if installed, with an inline fallback otherwise. `/code-review` commonly ships
-`disable-model-invocation`, which blocks the pipeline from calling it mid-run regardless
-of install state — the adversarial-subagent fallback is the realistic default for Step 7.
+`/cross-review` (from `codex-collaboration`), `humanizer`, and `ponytail` (whose
+`ponytail-review` is the Step 8 deletion lens, and whose lazy mode shapes the design from
+Step 4 on). Each is used if installed, with an inline fallback otherwise.
 
 ## Usage
 

--- a/plugins/issue-to-pr/skills/run/SKILL.md
+++ b/plugins/issue-to-pr/skills/run/SKILL.md
@@ -40,9 +40,10 @@ own judgment. One todo per step.
 
 - **Config** (`.claude/issue-to-pr/config.md`, optional): `preflight.sh` parses it and
   resolves the base (schema `R/configuration.md`); read it in the main checkout up front
-  (gitignored, absent in the worktree). Gate commands come from it, or from you at Step 6. **Companions** (if installed,
-  else inline): `superpowers:*`, `/deep-research`, `/cross-review`, `humanizer`,
-  `/code-review` (`R/companions.md`).
+  (gitignored, absent in the worktree). Gate commands come from it, or from you at Step 6.
+  **Built in, no install:** `code-review` (Step 7), `simplify` (Step 8). **Companions** (if
+  installed, else inline): `superpowers:*`, `/deep-research`, `/cross-review`, `humanizer`,
+  `ponytail:*` — all in `R/companions.md`.
 - **Tier** (`R/tier-matrix.md`): you pick it at Step 2, `standard` unless the issue argues
   otherwise; it routes research, design, review level/passes, security overlay, report length.
 - **Autonomy** (`R/autonomy.md`, read once at Step 0): the ask contract (three contact
@@ -102,13 +103,13 @@ test='<test_cmd>'` (+ `--gate visual=…` for UI). Never judge a gate from an ad
 this one surfaces the real failure instead of a summarised "no tests collected". An empty gate
 command degrades (exit 4), never a false green. Red ⇒ STOP and fix.
 
-**7. Review loop.** Default to the inline fallback: independent adversarial review
-subagents critique the diff at the tier's level, ≤ tier's max passes. `/code-review
-<level> --fix` is preferred only when it's actually callable — most copies ship
-`disable-model-invocation`, which blocks a skill run from invoking it at all (`R/companions.md`).
-Run them in the **foreground**, never while gates run — a reviewer editing the shared worktree
-mid-gate produces a phantom red. Ponytail rides in with them: their prompt says it governs how a
-confirmed bug gets fixed, never whether it counts as one.
+**7. Review loop.** Claude Code's built-in `code-review` skill at the tier's level, ≤ tier's max
+passes, and **without `--fix`** — that flag applies findings in one sweep, past the per-fix re-gate
+and the bug count the ratchet reads. Add adversarial subagents when the diff earns a second
+opinion (`R/companions.md`). Run
+reviewers in the **foreground**, never while gates run — one editing the shared worktree mid-gate
+produces a phantom red. Ponytail rides in with them: their prompt says it governs how a confirmed
+bug gets fixed, never whether it counts as one.
 **Security overlay:** `S/changed-paths.sh --base "<BASE>"` lists
 what this branch touched (committed, uncommitted, untracked); you decide from the diff whether
 it reaches auth, crypto, secrets, sessions, payments or migrations, and add one
@@ -116,13 +117,13 @@ it reaches auth, crypto, secrets, sessions, payments or migrations, and add one
 **escalate a level** on 2+ confirmed bugs/pass or a gate failing twice; re-run gates
 after each fix.
 
-**8. Re-gates + ponytail.** Re-run `run-gates.sh` (all green). If commands you worked out
-yourself passed and config lacks them, **print the frontmatter block** for `<CONFIG_PATH>` in
-the report for the user to paste. Never write it yourself: the file can be tracked and shared.
-**Final gate, when ponytail is installed:** `/ponytail:ponytail-review` over `git diff <BASE>`
-(two dots — Step 9 has not committed yet, so `<BASE>...HEAD` compares two commits and shows an
-empty diff here) plus any untracked file `S/changed-paths.sh --base "<BASE>"` names. Apply the
-cuts you agree with and re-run gates; answer the rest in one line each in the report.
+**8. Re-gates + simplification gate.** Re-run `run-gates.sh` (all green). For any gate command you
+worked out yourself, **print** (never write) the `<CONFIG_PATH>` frontmatter block in the report.
+Then the **simplification gate**, at most two passes: `/ponytail:ponytail-review` (when installed)
+for what to delete, built-in `simplify` for what stays but gets simpler, over `git diff <BASE>` (two dots, never
+three) plus any untracked file `S/changed-paths.sh --base "<BASE>"` names. Apply the cuts you
+agree with, re-run gates, stop as soon as a pass finds nothing; the rest gets one line each in
+the report. Lenses, fallbacks, why two dots and why the cap is two: `R/companions.md`.
 
 **9. Commit + PR.** `git add <explicit paths>`, conventional subjects; `git push -u origin
 <branch>`. **Re-run `run-gates.sh` on the commit**: it leaves the receipt Step 11 checks, and a

--- a/plugins/issue-to-pr/skills/run/references/autonomy.md
+++ b/plugins/issue-to-pr/skills/run/references/autonomy.md
@@ -46,7 +46,7 @@ can land on the wrong one.
   "ledger": [{"question": "…", "decision": "…", "rationale": "…", "kind": "auto"}],
   "metrics": {"gate_runs": 3, "gate_fail_streak": {}, "confirmed_bugs_this_pass": 0,
     "review_passes": 2, "review_level": "medium", "design_panel_ran": false,
-    "started_at": "…"} }
+    "simplify_passes": 1, "started_at": "…"} }
 ```
 
 - `tier` is written after Step 2 (null/pending before that).

--- a/plugins/issue-to-pr/skills/run/references/companions.md
+++ b/plugins/issue-to-pr/skills/run/references/companions.md
@@ -15,27 +15,55 @@ companion silently degrade quality without saying so.
 | Design generation (Step 4, complex+) | `workflows/design-panel.js` (3 proposers → 2 adversarial critics → opus judge), with `/cross-review` critiquing the produced `design_md` | Inline self-review chain: draft, adversarially self-critique against the code, revise. |
 | Humanizing human-facing text (Step 9–10) | `humanizer` | Self-edit the PR body / report to drop AI-tell phrasing; flag that a humanizer pass would help. |
 | Lazy design and build (Steps 4–5) | `ponytail:ponytail full`, set once before the design | Design and build against the same ladder by hand: does this need to exist, does the stdlib or the platform already do it, can it be one line. |
-| Final over-engineering gate (Step 8) | `ponytail:ponytail-review` over the run's diff | Re-read the diff hunting only for what to delete: reinvented stdlib, one-caller abstractions, config nobody sets, flags nobody passes. |
-| Diff review loop (Step 7) | `/code-review` — only if callable (see note) | Independent adversarial review subagents (2–3 reviewers) critique the diff for correctness, reuse, and regressions; iterate. This is the default in practice. |
+| Deletion lens (Step 8) | `ponytail:ponytail-review` over the run's diff | Re-read the diff hunting only for what to delete: reinvented stdlib, one-caller abstractions, config nobody sets, flags nobody passes. |
+| Simplification lens (Step 8) | `simplify`, built into Claude Code: four angles (reuse, simplification, efficiency, altitude) over the same diff, and it applies what it finds | Re-read the diff for what survives but reads worse than it has to: a branch that only ever takes one path, a loop the stdlib has a name for, a comment explaining a name that should have been the name. |
+| Diff review loop (Step 7) | `code-review`, built into Claude Code: takes a level and reports findings. It also takes `--fix`; Step 7 does not use it (see the note) | Independent adversarial review subagents (2–3 reviewers) critique the diff for correctness, reuse, and regressions; iterate. |
 
-## Install hints (same marketplace)
+## Install hints
 
 - `humanizer` and `codex-collaboration` ship in this marketplace
   (`DmitriyYukhanov/claude-plugins`): `/plugin install humanizer`,
   `/plugin install codex-collaboration`. `codex-collaboration` additionally needs the Codex
   plugin and `/codex:setup`.
 - `superpowers:*` is the external Superpowers plugin, `ponytail:*` the external Ponytail one
-  (`DietrichGebert/ponytail`). `/deep-research` and `/code-review` come from your own setup or
-  other plugins.
+  (`DietrichGebert/ponytail`). `/deep-research` comes from your own setup or another plugin.
+- `code-review` and `simplify` need no install at all; see the note below.
 
-## Note: `/code-review` is usually unreachable from inside the pipeline
+## Note: two of these companions are built into Claude Code
 
-`disable-model-invocation: true` on a command means only a human typing it triggers it —
-the model's own SlashCommand tool cannot invoke it, even from inside a skill run. Most
-`/code-review` copies set this deliberately (it's meant for a human to run directly), so
-Step 7 calling it mid-pipeline is a no-op, not a degraded case: it never fires and the
-inline fallback runs instead. Don't treat "installed" as "callable" — the fallback is the
-realistic default, not a rare miss.
+`code-review` and `simplify` are registered by the CLI itself, alongside `verify`, `commit`, `pr`
+and `workshop`. Invoke them like any skill, by name, with no namespace prefix. They need no
+install and no marketplace, and no `if installed` branch applies to them.
+
+Do not confuse the built-in `code-review` skill with the plugin command of the same name in the
+official marketplace. Searching `~/.claude/plugins/cache` finds the plugin and tells you nothing
+about the built-in, which is exactly the mistake this file used to enshrine: it claimed
+`/code-review` was unreachable from a skill run because copies ship `disable-model-invocation`,
+and sent Step 7 to an inline fallback for releases while the real reviewer sat one call away. The
+cached official copy sets `disable-model-invocation: false`, so the caveat did not even hold for
+the plugin. Before concluding a capability is missing, check whether it ships in the CLI.
+
+**Step 7 skips `--fix` on purpose.** The built-in reviewer can apply its own findings with that
+flag. The pipeline does not let it, because a sweep of applied fixes lands past the per-fix
+re-gate and past `confirmed_bugs_this_pass`, which is the number the escalation ratchet reads.
+Fix findings yourself, one at a time, and re-run the gates between them.
+
+## The Step 8 simplification gate
+
+Both lenses are rows in the table above, and their inline fallbacks are the right-hand column.
+What follows is why the two numbers in the spine's Step 8 are both two. One instruction that
+lives only here: record the pass count in `state.json.metrics.simplify_passes`, so the Step 10
+report shows whether the gate converged or hit its cap.
+
+**Two dots, never three.** Step 8 runs before Step 9 commits, so on a fresh branch HEAD is still
+the base and `git diff <BASE>...HEAD` compares a commit with itself: zero files, while the whole
+run sits uncommitted in the worktree. That is how the gate reviewed nothing and reported clean
+from v2.7.0 to v4.0.0; v4.1.0 is the release that fixed it. `git diff <BASE>` reads the working tree; `changed-paths.sh` covers the
+files git has never seen.
+
+**Why the cap is two.** One pass cannot check itself: it edits the code and then stops looking,
+so a cut that broke a neighbouring path reaches the gates at best and nobody at worst. Pass 2
+earns its keep by reading what pass 1 changed; a third reads a diff that stopped moving.
 
 ## Note: ponytail carries itself, and it reaches the reviewers too
 

--- a/plugins/issue-to-pr/skills/run/references/configuration.md
+++ b/plugins/issue-to-pr/skills/run/references/configuration.md
@@ -58,6 +58,8 @@ as an alias for the top-level `*_cmd` scalars.)
 the **main checkout**, where it lives and the only tree certain to exist that early.
 
 A command this file does not name comes back empty, and the run works it out at Step 6 in the
-worktree the gates execute in, always as a literal such as `npm test`. A repository whose suite
+worktree the gates execute in, always as a literal such as `npm test`. Step 8 then prints the
+frontmatter block for you to paste, and never writes this file itself: the path is gitignored by
+default, but nothing stops a project from tracking and sharing it. A repository whose suite
 is genuinely ambiguous, a monorepo with one per package, gets asked about rather than guessed
 at, and the answer belongs here. Never invent a command.

--- a/plugins/issue-to-pr/skills/run/references/tier-matrix.md
+++ b/plugins/issue-to-pr/skills/run/references/tier-matrix.md
@@ -15,7 +15,7 @@ ledger with the signal that moved it.
 | Design | - | mini-design in the PR body | **design-panel** or `/cross-review` | **decompose** into children (`epic.md`) |
 | Plan | - | inline checklist | writing-plans | per child |
 | Tests / gates | always | always | always | per child |
-| `/code-review` | `low --fix`, 1 pass | `medium --fix`, <=2 passes | `high --fix`, <=3 passes (may raise to `max` on escalation) | per child + `ultra` on integrator PRs |
+| `code-review` level | `low`, 1 pass | `medium`, <=2 passes | `high`, <=3 passes (may raise to `max` on escalation) | per child + `max` on integrator PRs |
 | Security overlay | if sensitive paths | if sensitive paths | if sensitive paths | mandatory sweep |
 | Report | 3 lines | short | full | dashboard |
 
@@ -54,7 +54,7 @@ These paths are a floor you may escalate from and never argue down: anything und
 
 ## Escalation ratchet (one-way)
 
-Track in `state.json.metrics`: `confirmed_bugs_this_pass` (count of `/code-review`
+Track in `state.json.metrics`: `confirmed_bugs_this_pass` (count of `code-review`
 CONFIRMED verdicts) and `gate_fail_streak.<gate>`. When **2+ confirmed bugs land in
 one review pass**, or **the same gate fails twice**, escalate the review level one
 notch (never down); trivial->standard also re-enters the design step. Surface the raw

--- a/plugins/issue-to-pr/tests/contract/test_skill-lint.sh
+++ b/plugins/issue-to-pr/tests/contract/test_skill-lint.sh
@@ -15,6 +15,26 @@
 
 skill_md() { printf '%s' "$ITP_SCRIPTS/../skills/run/SKILL.md"; }
 
+# The spine is one file, so a bare assert_contains on it passes when the string it wants has
+# drifted into some other step. Tests about one step read that step's own block.
+#
+# Steps come in two shapes: `**7. Review loop.**` inline, and `## Step 11 — ...` as a heading.
+# Both start and end a block. The terminator matches a NUMBERED heading only, never any bold run
+# that happens to lead with a digit: `**2+ confirmed bugs**` mid-paragraph used to end the slice
+# early and silently shrink whatever the test was checking.
+#
+# An empty slice is NOT self-announcing: assert_contains fails on it, assert_not_contains passes.
+# So the caller gets a hard failure instead, and no assertion ever runs against nothing.
+skill_step() { # step-number
+  local out
+  out=$(awk -v n="$1" '
+    index($0, "**" n ". ")==1 || index($0, "## Step " n " ")==1 {f=1; print; next}
+    /^\*\*[0-9]+(\.[0-9]+)?\. / || /^## Step [0-9]/ {f=0}
+    f' "$(skill_md)")
+  [ -n "$out" ] || fail "SKILL.md has no Step $1 block; the heading was renamed or removed"
+  printf '%s\n' "$out"
+}
+
 test_skill_within_line_budget() {
   local n
   n=$(wc -l <"$(skill_md)")
@@ -85,8 +105,8 @@ test_skill_sets_ponytail_mode_at_design_not_at_the_final_gate() {
   c=$(cat "$(skill_md)")
   # Placement, not just presence: a `full` that drifted down to Step 8 would still satisfy a
   # bare "contains" check while setting the mode after the design it was meant to shape.
-  printf '%s\n' "$c" | grep '^\*\*4\. Design\*\*' | grep -q '/ponytail:ponytail full' ||
-    fail "Step 4's own line must be where ponytail's mode is set"
+  assert_contains "$(skill_step 4)" '/ponytail:ponytail full' \
+    "Step 4's own block must be where ponytail's mode is set"
   assert_not_contains "$c" "ponytail:ponytail ultra" \
     "the final gate must not switch modes; ponytail-review ignores the session mode"
 }
@@ -96,12 +116,47 @@ test_skill_sets_ponytail_mode_at_design_not_at_the_final_gate() {
 # the worktree. The gate reviewed nothing and reported clean.
 test_skill_final_review_reads_the_uncommitted_worktree() {
   local c
-  c=$(cat "$(skill_md)")
-  assert_contains "$c" 'ponytail-review` over `git diff <BASE>`' \
+  c=$(skill_step 8)
+  assert_contains "$c" 'over `git diff <BASE>`' \
     "the final review diffs the base against the working tree, not one commit against another"
   # Two dots still miss a file git has never seen, and a run that adds one is the common case.
-  # Anchored on "untracked file" because the bare command string also appears in Step 7, where
-  # it would satisfy a looser assertion no matter what Step 8 said.
+  # Step 7 names the same script for the security overlay, which is why this reads Step 8 alone.
   assert_contains "$c" 'untracked file `S/changed-paths.sh --base "<BASE>"` names' \
     "the final review is handed the untracked files too"
+}
+
+# Step 8 ran `ponytail-review` once. One pass only hunts what to delete, never what to make
+# simpler in place, and nothing re-reads the diff after its own cuts land, so a cut that broke a
+# neighbouring path reached the gates at best and nobody at worst. The gate is now two lenses
+# over two passes, capped at two: pass 2 pays for itself by reading what pass 1 edited, a third
+# would spend tokens on a diff that has stopped moving.
+test_skill_simplification_gate_is_two_passes() {
+  local c
+  c=$(skill_step 8)
+  assert_contains "$c" "at most two passes" \
+    "Step 8 must state the cap out loud; an uncapped loop is what the cap exists to prevent"
+  assert_contains "$c" 'built-in `simplify`' \
+    "the simplification lens is the skill Claude Code ships, not a hand-rolled pass"
+  # Both lenses, and the deletion one keeps its plugin namespace. A bare `ponytail-review` does
+  # not resolve, so the gate would quietly run on one lens while still claiming two.
+  assert_contains "$c" '/ponytail:ponytail-review' \
+    "the deletion lens needs its plugin prefix or the call finds no such skill"
+}
+
+# companions.md claimed `/code-review` was unreachable from a skill run because most copies ship
+# `disable-model-invocation`. True of plugin commands by that name, false of the skill Claude Code
+# registers itself, and acting on it sent Step 7 to an inline fallback for several releases while
+# the real reviewer sat one call away. The built-in does take `--fix`; the pipeline declines it,
+# because one sweep of applied fixes lands past the per-fix re-gate and past the bug count the
+# escalation ratchet reads. The tier table is where `--fix` used to live, so guard it there too.
+test_skill_review_loop_uses_the_builtin_code_review() {
+  local c tiers
+  c=$(skill_step 7)
+  assert_contains "$c" 'built-in `code-review` skill' \
+    "Step 7 must reach for the reviewer Claude Code ships instead of defaulting to a fallback"
+  assert_contains "$c" 'without `--fix`' \
+    "Step 7 must say it declines the reviewer's own fix sweep, and why"
+  tiers=$(cat "$ITP_SCRIPTS/../skills/run/references/tier-matrix.md")
+  assert_not_contains "$tiers" '--fix' \
+    "the tier table sets the review level; it must not hand the reviewer a fix sweep"
 }


### PR DESCRIPTION
## What changed

Two things, and the second one turned out to matter more.

**Step 8 is now a simplification gate.** It ran `ponytail-review` once, which leaves two holes: one pass only hunts what to delete, never what to make simpler in place, and nothing re-reads the diff after its own cuts land, so a cut that broke a neighbouring path reached the gates at best and nobody at worst. It is now two lenses over at most two passes: `/ponytail:ponytail-review` for what to delete, the built-in `simplify` for what stays but reads worse than it has to, both over `git diff <BASE>` plus the untracked files `changed-paths.sh` names. Each pass applies the cuts you agree with, re-runs the gates, and answers the rest one line each in the report. A pass that finds nothing ends the loop, and there is never a third. The count lands in `state.json.metrics.simplify_passes`.

**Step 7 was avoiding a reviewer that was always there.** `companions.md` claimed `/code-review` was unreachable from a skill run because most copies ship `disable-model-invocation`, so Step 7 defaulted to inline reviewers. That caveat describes a *plugin command*; the reviewer Claude Code registers itself is a different thing entirely, needs no install, and was one call away the whole time. The cached official plugin copy on this machine sets `disable-model-invocation: false`, so the caveat did not even hold for the plugin. Step 7 now names the built-in.

It declines `--fix`, and for the real reason: the built-in does have that flag, but one applied sweep lands past the per-fix re-gate and past `confirmed_bugs_this_pass`, which is the number the escalation ratchet reads.

## What the review caught

The first pass with real review agents, allowed for this PR, returned eight defects on a diff that had already cleared an inline review, both simplification passes, and a CodeRabbit review. Three of them this PR introduced while fixing the previous mistake.

- I wrote in three places that the built-in reviewer "reports findings and never edits". It has `--fix`. The conclusion survives; the stated reason was false and is now the true one.
- Rewriting Step 8 stripped `/ponytail:` off `ponytail-review`. A bare name does not resolve, so the two-lens gate would have run one lens while still calling itself two. No assertion covered the deletion lens; one does now.
- `skill_step`, the helper added last round, ended a block on any bold run starting with a digit. Reproduced: rewording a line to `**2+ confirmed bugs**` truncated Step 7's slice and let `--fix` inside Step 7 pass the assertion meant to catch it.
- `skill_step 10` returned 45 lines, running through Steps 11 and 12 to end of file; `skill_step 11` and `12` returned nothing, because those are `## Step N` headings. An empty slice is not harmless: `assert_contains` fails on it but `assert_not_contains` passes. The slicer now knows both heading shapes and fails loudly on an empty slice.
- `README.md` still carried the retracted claim word for word, and SKILL.md line 45 still listed `/code-review` under "companions (if installed, else inline)", sixty lines above the step that was supposed to stop doing that.
- `companions.md` dated the broken-gate window "v2.7.0 to v4.1.0". v4.1.0 is the release that fixed it.
- My own note told readers that searching `~/.claude/plugins/cache` would turn up nothing. It turns up the official `code-review` plugin. The note now explains the distinction instead of denying the plugin exists.

## Mini-design

Prose and tests only: the spine's Steps 7 and 8 and its companion list, four reference files, the plugin README, one contract-test file. No script changed.

Rejected: a third simplification pass, or an uncapped loop. Two is where the cost stops buying anything, and the cap has to be a number the spine states out loud, since "until clean" against a model's own judgment is not a bound.

Rejected: keeping the `--fix` ban as an assertion that the flag does not exist. It does. The assertion now requires Step 7 to say it declines the flag and why, and the ban on `--fix` moved to `tier-matrix.md`, which is where the flag actually used to live.

## Decisions made autonomously

- Tier `standard`.
- `simplify_passes` goes in the existing `metrics` object rather than a new state field.
- Shipping at exactly 180 of the 180-line budget rather than churning prose to buy a line. The budget exists to push detail into references, and the next change can pay that cost when it needs the room.
- The Step 7 rework landed in this PR rather than a follow-up, at your call.

## Test status

`bash plugins/issue-to-pr/tests/run-tests.sh`: 146 passed, 0 failed. Green before the simplification passes, after them, after the CodeRabbit fix, and again after the agent-review fixes.

Closes #44


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added built-in code review and simplification checks to the issue-to-PR workflow.
  - Added deletion and simplification review passes, with a maximum of two iterations.
  - Updated complex workflow escalation to use the maximum review tier.

- **Documentation**
  - Clarified built-in and optional review tools, configuration behavior, installation guidance, and workflow stages.
  - Added release notes for version 4.2.0.

- **Tests**
  - Expanded validation to verify review and simplification steps use the expected tools and options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->