### PR TITLE
feat(issue-to-pr): --drill hands the design to the human before it gets built (v4.3.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -130,7 +130,7 @@
     {
       "name": "issue-to-pr",
       "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp files; the issue auto-closes on merge and the board card advances as work moves.",
-      "version": "4.2.0",
+      "version": "4.3.0",
       "author": {
         "name": "Dmitry Yuhanov"
       },

--- a/plugins/issue-to-pr/.claude-plugin/plugin.json
+++ b/plugins/issue-to-pr/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "issue-to-pr",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp files; the issue auto-closes on merge and the board card advances as work moves.",
   "author": {
     "name": "Dmitry Yuhanov"

--- a/plugins/issue-to-pr/CHANGELOG.md
+++ b/plugins/issue-to-pr/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the **issue-to-pr** plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [4.3.0] - 2026-08-25
+
+### Added
+- Add `--drill`, which hands the design to the drill tutor before anything gets built, for runs where you would rather understand the plan than save the time
+
 ## [4.2.0] - 2026-08-25
 
 ### Changed

--- a/plugins/issue-to-pr/README.md
+++ b/plugins/issue-to-pr/README.md
@@ -14,10 +14,10 @@ as work progresses.
 
 ## Features
 
-### Skill: `issue-to-pr`
+### Skill: `run`
 
 Invoked by the model or by you (`/issue-to-pr:run [issue-number | next | "free text"]
-[--tier trivial|standard|complex|epic]`). The pipeline runs triage, research, design,
+[--tier trivial|standard|complex|epic] [--drill]`). The pipeline runs triage, research, design,
 implementation, review, PR, approval-gated merge, and cleanup. Hard gates block forward
 progress; everything between them scales to the task.
 
@@ -27,9 +27,11 @@ progress; everything between them scales to the task.
 - **Scaled by tier.** Triage evidence assigns a tier from trivial to epic (`--tier`
   overrides). Research depth, design machinery (an autonomous design panel for complex
   work), review level and passes, the security overlay, and report length all size to it.
-- **Autonomous, one question max.** The skill contacts you at exactly three moments: one
+- **Autonomous, one question max.** The skill contacts you at three moments: one
   batched question mid-run (only if something genuinely needs your preference), the merge
-  gate, and hard stops. It makes every other decision itself, logs it, and surfaces it in
+  gate, and hard stops. Pass `--drill` and it adds a fourth on purpose: the `drill` tutor
+  walks you through the design before anything is built, and whatever you dispute there is
+  folded into that same batched question. It makes every other decision itself, logs it, and surfaces it in
   the report and PR body.
 - **Gates.** Design hardening (cross-review or a multi-agent fallback), tests green
   (typecheck + tests, plus visual checks for UI work), and a code-review loop that runs

--- a/plugins/issue-to-pr/skills/run/SKILL.md
+++ b/plugins/issue-to-pr/skills/run/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   N", "work on issue #N", "do the next task", "build/fix X" when no issue exists yet, and —
   for the merge gate later — "merge it", "approve the PR", "ship it", "lgtm merge".
 user-invocable: true
-argument-hint: "[issue-number | next | \"free text\"] [--tier trivial|standard|complex|epic]"
+argument-hint: "[issue-number | next | \"free text\"] [--tier trivial|standard|complex|epic] [--drill]"
 ---
 
 # issue-to-pr — issue → merge-ready PR pipeline
@@ -26,7 +26,7 @@ own judgment. One todo per step.
 - **Merge is gated on explicit in-session approval**, runs ONLY in the main session, via
   `S/worktree.sh merge` — never a bare `gh pr merge`, never on the turn the PR opens. No file
   proves the go-ahead; keeping it is yours.
-- **Ask contract:** contact the user at exactly three moments — (1) ONE batched
+- **Ask contract:** three moments, four with `--drill` (`R/autonomy.md`) — (1) ONE batched
   `AskUserQuestion` at Step 4.5 (only if the ledger has open items), (2) the merge gate,
   (3) a hard stop. Decide everything else yourself and log it (see below).
 - Stage with **explicit paths** (`git add path1 path2`); never `git add -A`/`.` (a hook
@@ -46,8 +46,8 @@ own judgment. One todo per step.
   `ponytail:*` — all in `R/companions.md`.
 - **Tier** (`R/tier-matrix.md`): you pick it at Step 2, `standard` unless the issue argues
   otherwise; it routes research, design, review level/passes, security overlay, report length.
-- **Autonomy** (`R/autonomy.md`, read once at Step 0): the ask contract (three contact
-  moments; log every judgment call to `state.json.ledger[]` before the next tool call;
+- **Autonomy** (`R/autonomy.md`, read once at Step 0): the ask contract (three contact moments,
+  a fourth only with `--drill`; log every judgment call to `state.json.ledger[]` before the next call;
   auto-decisions rendered in the report + PR body), the `state.json` schema + the append-only
   `step.log` you write beside it, and the resume path (log wins over stale state).
 
@@ -78,17 +78,18 @@ a full 0–12 run.
 citing `path:line`; the raw file reads stay in its context, not yours.
 
 **4. Design** (tier routes it). **Ponytail installed → `/ponytail:ponytail full` first**, ledgered:
-design and implementation then run under the ladder. Complex+: `Workflow({scriptPath:
-"S/../workflows/design-panel.js", args:{issue,title,contextFiles,constraints,openQuestions}})`
-→ `design_md` (→ `<RUN_DIR>/design.md`) + rejected alternatives + open questions. Accept
-only if `received_issue` matches `<N>` **and** `design_md` is non-empty **and**
-`rejected_alternatives.length >= 1`. Any other outcome (including a thrown panel) → design
-inline; on a `received_issue` mismatch the panel never saw its args, so design the **whole**
-issue, not just the part a proposer reconstructed. `/cross-review` critiques the result.
-Preference-bound questions → ledger. Standard: a mini-design in the PR body.
+design and implementation then run under the ladder. Complex+: run the design panel
+(`S/../workflows/design-panel.js`) for `design_md` (→ `<RUN_DIR>/design.md`) + rejected
+alternatives — its args, the acceptance test its output must pass, and the design-inline
+fallback are in `R/contracts.md`. `/cross-review` critiques the result. Preference-bound
+questions → ledger. Standard: a mini-design in the PR body. **`--drill` → write the design to
+`<RUN_DIR>/design.md` whatever the tier**, including trivial: there is nothing to drill otherwise.
 
-**4.5. Checkpoint (unconditional slot).** If the ledger has open `asked` items, ask them in
-ONE batched `AskUserQuestion`. Empty ledger → no-op. The only mid-run question.
+**4.5. Checkpoint (unconditional slot).** `--drill` → hand `<RUN_DIR>/design.md` to `/drill:me`
+**first** (no plugin: hand the file over to read), appending each objection to
+`state.json.ledger[]` as it is raised, never at the end — a drill is long enough to compact
+(`R/autonomy.md`). Then ask any open `asked` items in ONE batched `AskUserQuestion`; a `--drill`
+run asks even on an empty ledger, or the design goes unanswered. The only mid-run question.
 
 **5. Plan + implement.** Turn the design into a plan (`superpowers:writing-plans` for
 complex+); TDD: failing test → implement → passing. UI/layout work is verified with
@@ -106,10 +107,9 @@ command degrades (exit 4), never a false green. Red ⇒ STOP and fix.
 **7. Review loop.** Claude Code's built-in `code-review` skill at the tier's level, ≤ tier's max
 passes, and **without `--fix`** — that flag applies findings in one sweep, past the per-fix re-gate
 and the bug count the ratchet reads. Add adversarial subagents when the diff earns a second
-opinion (`R/companions.md`). Run
-reviewers in the **foreground**, never while gates run — one editing the shared worktree mid-gate
-produces a phantom red. Ponytail rides in with them: their prompt says it governs how a confirmed
-bug gets fixed, never whether it counts as one.
+opinion (`R/companions.md`). Run reviewers in the **foreground**, never while gates run — one
+editing the shared worktree mid-gate produces a phantom red. Ponytail rides in with them: their
+prompt says it governs how a confirmed bug gets fixed, never whether it counts as one.
 **Security overlay:** `S/changed-paths.sh --base "<BASE>"` lists
 what this branch touched (committed, uncommitted, untracked); you decide from the diff whether
 it reaches auth, crypto, secrets, sessions, payments or migrations, and add one

--- a/plugins/issue-to-pr/skills/run/references/autonomy.md
+++ b/plugins/issue-to-pr/skills/run/references/autonomy.md
@@ -3,14 +3,36 @@
 The pipeline decides what it reasonably can on its own, records every decision, and
 surfaces the automatic ones where the human already looks (the report and the PR body).
 
-## Ask contract — three moments only
+## Ask contract — three moments, plus one the user asks for
 
-Contact the user at exactly three points:
+Contact the user at these three points, and at a fourth only if asked (below):
 1. **Step 4.5 checkpoint** — ONE batched `AskUserQuestion`, only if the ledger has open
    `asked` items. This is the single mid-run question.
 2. **The merge gate** (Step 11) — always.
 3. **A hard stop** — an exit-2 with no safe default (e.g. `WARN_CLAIMED_BY`, a
    gate-critical unknown).
+
+**A fourth moment exists only when the run was started with `--drill`.** Every other rule here
+saves the user's time; this one spends it, because they asked to understand the design while it
+can still change.
+
+Step 4 writes `<RUN_DIR>/design.md` for a `--drill` run at any tier, including trivial. Without
+that the flag is inert on the two commonest tiers: standard keeps its mini-design in the PR body,
+which does not exist until Step 9, and trivial designs nothing at all.
+
+At Step 4.5, before the batched question, hand that file to `/drill:me`. There is no return
+value to collect: the drill runs in this session, so **you** append each objection to the run's
+`state.json.ledger[]` as an `asked` item the moment it is raised. Not at the end — a tutoring
+session is long enough to compact this context, and an objection that lives only in the
+conversation is gone when it does. Note also that drill keeps a "ledger" of its own in
+`~/.drill-me/`; that one is not yours.
+
+The batched question then carries what the drill raised. A `--drill` run asks it even when the
+ledger is empty, since "no open items" after a drill means the design was never put to them.
+
+With the flag and no `drill` plugin installed, say so once, hand over `<RUN_DIR>/design.md` to
+read, and ask for objections in that same batched question — never silently skip what was
+asked for.
 
 A question is for the user (`kind: asked`) only when it is:
 - **preference-bound** — public API naming, user-visible UX/copy, paid/external

--- a/plugins/issue-to-pr/skills/run/references/companions.md
+++ b/plugins/issue-to-pr/skills/run/references/companions.md
@@ -17,6 +17,7 @@ companion silently degrade quality without saying so.
 | Lazy design and build (Steps 4–5) | `ponytail:ponytail full`, set once before the design | Design and build against the same ladder by hand: does this need to exist, does the stdlib or the platform already do it, can it be one line. |
 | Deletion lens (Step 8) | `ponytail:ponytail-review` over the run's diff | Re-read the diff hunting only for what to delete: reinvented stdlib, one-caller abstractions, config nobody sets, flags nobody passes. |
 | Simplification lens (Step 8) | `simplify`, built into Claude Code: four angles (reuse, simplification, efficiency, altitude) over the same diff, and it applies what it finds | Re-read the diff for what survives but reads worse than it has to: a branch that only ever takes one path, a loop the stdlib has a name for, a comment explaining a name that should have been the name. |
+| Human drill on the design (Step 4.5, `--drill` only) | `drill:me` — the tutor drills the user on the design before it is built | Hand them `<RUN_DIR>/design.md`, say the drill plugin would have made this interactive, and take objections in the same batched question. |
 | Diff review loop (Step 7) | `code-review`, built into Claude Code: takes a level and reports findings. It also takes `--fix`; Step 7 does not use it (see the note) | Independent adversarial review subagents (2–3 reviewers) critique the diff for correctness, reuse, and regressions; iterate. |
 
 ## Install hints

--- a/plugins/issue-to-pr/skills/run/references/contracts.md
+++ b/plugins/issue-to-pr/skills/run/references/contracts.md
@@ -142,3 +142,16 @@ your call at Step 7, not the script's (`tier-matrix.md`).
 
 PreToolUse hook (in `hooks/hooks.json`, alongside merge-guard): denies `git add -A` / `--all`
 / `.` and passes everything else through, so staging stays explicit. You never call it directly.
+
+## workflows/design-panel.js — Step 4 design, complex+ only
+
+Called as `Workflow({scriptPath: "S/../workflows/design-panel.js", args:{issue, title,
+contextFiles, constraints, openQuestions}})`. Three proposers, two adversarial critics, an
+opus judge; it returns `design_md`, `rejected_alternatives` and open questions.
+
+**Accept the result only if all three hold:** `received_issue` equals the issue number you
+passed, `design_md` is non-empty, and `rejected_alternatives.length >= 1`. Anything else,
+including a panel that throws, means design inline instead.
+
+A `received_issue` mismatch looks like partial success and is not: the panel never saw its args,
+so design the **whole** issue yourself, not the part a proposer reconstructed.

--- a/plugins/issue-to-pr/tests/contract/test_skill-lint.sh
+++ b/plugins/issue-to-pr/tests/contract/test_skill-lint.sh
@@ -160,3 +160,46 @@ test_skill_review_loop_uses_the_builtin_code_review() {
   assert_not_contains "$tiers" '--fix' \
     "the tier table sets the review level; it must not hand the reviewer a fix sweep"
 }
+
+# `--drill` is the one way a run spends the human's time on purpose instead of saving it: it
+# hands the design to /drill:me at the checkpoint. Ordering is the contract, not decoration —
+# the drill runs BEFORE the batched question so an objection it surfaces still fits in that
+# same slot rather than needing a second one. A flag nobody can discover is a flag nobody
+# passes, so the frontmatter has to advertise it too.
+test_skill_drill_is_opt_in_and_precedes_the_batched_question() {
+  local blk d a
+  grep -q 'argument-hint:.*--drill' "$(skill_md)" ||
+    fail "argument-hint must advertise --drill"
+  blk=$(skill_step 4.5)
+  d=$(printf '%s\n' "$blk" | grep -n '/drill:me' | head -1 | cut -d: -f1)
+  a=$(printf '%s\n' "$blk" | grep -n 'AskUserQuestion' | head -1 | cut -d: -f1)
+  [ -n "$d" ] || fail "Step 4.5 must run /drill:me when the flag asked for it"
+  [ -n "$a" ] || fail "Step 4.5 lost its batched AskUserQuestion"
+  [ "$d" -le "$a" ] ||
+    fail "the drill must come before the batched question, not after it"
+  # The flag was inert on the two commonest tiers until Step 4 wrote the design unconditionally:
+  # standard keeps its mini-design in the PR body, which does not exist yet at 4.5, and trivial
+  # designs nothing. Both branches of 4.5 hand over a file, so that file has to be produced.
+  assert_contains "$(skill_step 4)" '`<RUN_DIR>/design.md` whatever the tier' \
+    "a --drill run must write the design at every tier, or there is nothing to drill"
+  # And the fallback needs a slot to collect objections in. Step 4.5 skips the question on an
+  # empty ledger, which is exactly the state a no-plugin drill run is in.
+  assert_contains "$blk" 'even on an empty ledger' \
+    "a --drill run must ask even when nothing else queued a question"
+}
+
+# The ask contract says "three moments only". A drill the user opted into is a fourth, and a
+# contract that contradicts the step it governs is worse than no contract.
+test_autonomy_accounts_for_the_drill() {
+  local a
+  a=$(cat "$ITP_SCRIPTS/../skills/run/references/autonomy.md")
+  assert_contains "$a" '--drill' \
+    "autonomy.md must name the opt-in fourth contact moment it now allows"
+  # And no copy of the contract may still state the old absolute. The spine carried
+  # "contact the user at exactly three moments" under **Hard rules (never violate)** while the
+  # step below it described a fourth: a rule the pipeline breaks by design is worse than none.
+  assert_not_contains "$a" 'exactly three' \
+    "autonomy.md still asserts the three-moment absolute a --drill run breaks"
+  assert_not_contains "$(cat "$(skill_md)")" 'exactly three' \
+    "the spine's hard rules still assert the three-moment absolute a --drill run breaks"
+}


### PR DESCRIPTION
## What changed

The pipeline is autonomous by contract and asks at most one batched question. Sometimes the point is not to save your time but to spend it: you want to understand what is about to be built while it can still change.

`--drill` adds exactly that, and only when you ask for it. With the flag and the `drill` plugin installed, Step 4.5 hands the design to `/drill:me` and lets the tutor drill you on the decisions and the rejected alternatives, **before** the batched question. Whatever you dispute becomes an `asked` item in the run's ledger, so the same question carries it.

Ordering is the contract rather than decoration. After the question, an objection raised in the drill would need a second interruption, which is the thing the ask contract exists to prevent. A contract test asserts the position, not just the presence, and it fails when the two are swapped.

Without the flag nothing changes. With the flag and no `drill` plugin, the run says so once, hands over `<RUN_DIR>/design.md` to read, and folds any objection into the same batch rather than silently skipping what you asked for.

## The contract said "exactly three moments" in four places

One of them sat under **Hard rules (never violate)** in the spine, so a `--drill` run would have broken a rule the skill declares unbreakable. A rule the pipeline violates by design is worse than no rule. All four statements now agree, and an assertion keeps the absolute from coming back.

## Two hazards the drill brings with it

Both are now written down where they bite, because neither is visible from the pipeline's side alone.

The word "ledger" means two different things once the drill is running. Drill keeps its own in `~/.drill-me/`; the run keeps `state.json.ledger[]`. The model reads both skills in one session, so the reference names the run's explicitly.

A tutoring session is long enough to compact the context. If your objections live only in the model's head until the drill ends, they are gone by the time the batched question runs, and the feature quietly fails at the one job it was added for. The rule was already there in general form ("append before the next tool call"); it now says so for the drill specifically: write as objections come up, not at the end.

## Mini-design

Prose and tests: the spine's frontmatter, Step 4.5 and its two contract statements, three reference files, the plugin README, one contract-test file. No script changed. The spine was at 180 of its 180-line budget, so the design-panel acceptance detail moved to `references/contracts.md` to pay for the room, which is what the budget is for.

Rejected: a config field instead of a flag. The drill is a per-run decision about this design, not a project-wide setting, and a config value nobody revisits would drill you on runs you wanted to be autonomous.

Rejected: `-human-drills` as the flag name. `--drill` matches the existing `--tier` convention and is what you would guess.

Rejected: running the drill at Step 4 next to the design. Step 4.5 is the pipeline's one sanctioned interruption point; adding a second contact moment elsewhere is exactly what the ask contract forbids.

## Decisions made autonomously

- Tier `standard`.
- The `--drill` name, over the `-human-drills` the issue suggested.
- The stale `### Skill: issue-to-pr` heading in the README, wrong since the v4.0.0 rename, got fixed in the same edit that added the flag to the usage line.
- Two of three review agents signalled idle without reporting, so I verified their areas myself and logged the friction. The one that did report had to be asked directly.

## Test status

`bash plugins/issue-to-pr/tests/run-tests.sh`: 148 passed, 0 failed, including `test_skill_drill_is_opt_in_and_precedes_the_batched_question` and `test_autonomy_accounts_for_the_drill`. The ordering assertion was verified against a doctored copy with the drill moved after the question: it fails there, so it is not vacuous.

Closes #45


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in `--drill` option that lets users review and discuss the design before implementation begins.
  * Design feedback and objections are incorporated into the workflow and batched questions.
  * Added fallback guidance when the drill capability is unavailable.

* **Documentation**
  * Updated usage instructions, workflow guidance, companion references, and changelog for the new option.

* **Tests**
  * Added coverage to verify the drill option is advertised, runs at the correct stage, and preserves the expected interaction flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->