### PR TITLE
feat(issue-to-pr): a setup skill that walks the companions in (v4.4.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -130,7 +130,7 @@
     {
       "name": "issue-to-pr",
       "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp files; the issue auto-closes on merge and the board card advances as work moves.",
-      "version": "4.3.0",
+      "version": "4.4.0",
       "author": {
         "name": "Dmitry Yuhanov"
       },

--- a/plugins/issue-to-pr/.claude-plugin/plugin.json
+++ b/plugins/issue-to-pr/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "issue-to-pr",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp files; the issue auto-closes on merge and the board card advances as work moves.",
   "author": {
     "name": "Dmitry Yuhanov"

--- a/plugins/issue-to-pr/CHANGELOG.md
+++ b/plugins/issue-to-pr/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the **issue-to-pr** plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [4.4.0] - 2026-08-25
+
+### Added
+- Add `/issue-to-pr:setup`, which checks what the pipeline needs, says what each missing companion would sharpen, and hands you the install commands to run yourself
+
 ## [4.3.0] - 2026-08-25
 
 ### Added

--- a/plugins/issue-to-pr/README.md
+++ b/plugins/issue-to-pr/README.md
@@ -52,6 +52,14 @@ progress; everything between them scales to the task.
   at PR open; `Done` is left to GitHub's merge-time automation. A missing `project` token
   scope degrades to link-only and never blocks the PR.
 
+### Skill: `/issue-to-pr:setup`
+
+Run once before your first task. It checks the one hard requirement (`gh`, logged in, with
+the `repo` scope, plus `project` for board mode), reports which companion skills are present
+and what each missing one would sharpen, and prints the install command for each. It changes
+nothing on its own: the commands are yours to run. It also notes that `code-review` and
+`simplify` are built into Claude Code and need no install at all.
+
 ### Skill: `/issue-to-pr:tune`
 
 Runs leave one-line notes in a friction log when a step fought back. This skill batches

--- a/plugins/issue-to-pr/skills/setup/SKILL.md
+++ b/plugins/issue-to-pr/skills/setup/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: setup
+description: >-
+  Check what issue-to-pr needs and what would sharpen it, then hand the user the exact
+  install commands. Verifies gh auth and its scopes, reports which companion skills are
+  present and which step each missing one would improve, and explains the optional config
+  file. Prints commands for the user to run; installs nothing itself.
+when_to_use: When the user runs /issue-to-pr:setup, asks what issue-to-pr needs, or hits a
+  preflight failure about gh auth or a missing scope.
+argument-hint: ""
+user-invocable: true
+---
+
+# setup — what the pipeline needs, and what would sharpen it
+
+The pipeline runs standalone. One thing is genuinely required, everything else only makes a
+step better, and the run tells you when it fell back. This skill is the one place that says
+all of it at once, before the first run rather than in the middle of one.
+
+**You never run an install command here.** Print them and let the human decide. Installing a
+plugin changes their environment for every project, which is not a call a setup report makes.
+
+## 1. The hard requirement: `gh`
+
+Run `gh auth status`. Three outcomes:
+
+- **Not installed** → point at <https://cli.github.com/> and stop; nothing else matters yet.
+- **Installed, not logged in** → `gh auth login`.
+- **Logged in** → read the `Token scopes:` line. `repo` is required; `project` only for board
+  mode (`next`, and card sync at Steps 1 and 9), and without it the run still works on plain
+  issues and says once that board sync is off. Add one with `gh auth refresh -s project`.
+  No scopes line at all means a fine-grained token, not a broken login, and `gh auth refresh`
+  does not apply to one. Report the scopes as unknown rather than missing. On a repo with a
+  board, add that board sync will be skipped anyway: `preflight.sh` and `board-sync.sh` both
+  read that classic line, so a fine-grained token holding real project access still reads as
+  missing to them. Under-warning here defeats the point of running this before the first task.
+
+Report the account and the scopes you actually saw, not a summary of them.
+
+## 2. What ships in Claude Code already
+
+`code-review` (Step 7) and `simplify` (Step 8) are registered by the CLI itself. There is
+nothing to install and no marketplace involved, and an official plugin also called
+`code-review` is a different thing. Say they are present, so nobody goes looking.
+
+## 3. The companions
+
+Run `claude plugin list` and read what is installed and enabled. For each row below, report
+**present** or **missing**; for a missing one, say in one line what it buys and print the
+command. Never imply the pipeline is broken without them.
+
+| Companion | Buys you | Install |
+|---|---|---|
+| `ponytail` | Lazy mode from Step 4 on, so over-engineering is prevented rather than reviewed; its `ponytail-review` is one of the two Step 8 lenses | `/plugin marketplace add DietrichGebert/ponytail` then `/plugin install ponytail@ponytail` |
+| `superpowers` | Brainstorming, written plans, TDD discipline and systematic debugging at Steps 3–6, plus the done-claims rule that holds for the whole run | `/plugin marketplace add anthropics/claude-plugins-official` then `/plugin install superpowers@claude-plugins-official` |
+| `humanizer` | Step 9–10 prose that does not read like a machine wrote it | `/plugin install humanizer@dmitriy-claude-plugins` |
+| `drill` | `--drill` runs: the tutor walks you through the design at Step 4.5, before it is built | `/plugin marketplace add timini/drill-me` then `/plugin install drill@drill-me` |
+| `codex-collaboration` | `/cross-review`, a second model critiquing the design at Step 4 | Codex first: `/plugin marketplace add openai/codex-plugin-cc`, `/plugin install codex@openai-codex`, `/codex:setup`. Then `/plugin install codex-collaboration@dmitriy-claude-plugins` |
+| `/deep-research` | Step 3 research on external topics. Codebase questions go to a forked research subagent either way, so this is the smaller half | Comes from your own setup or another plugin |
+
+`../run/references/companions.md` carries the same list with the inline
+fallback each one degrades to. If a row here and a row there disagree, that file wins.
+
+## 4. The optional config
+
+`.claude/issue-to-pr/config.md` in the repo, gitignored, every field optional. Without it the
+run works the gate commands out at Step 6 and prints a block for you to paste. Worth setting
+up front only when the repo has a board, a non-default base branch, or a test command a
+newcomer would guess wrong. Schema: `../run/references/configuration.md`.
+
+Never write this file from here. It can be tracked and shared, so what lands in it is the
+user's decision.
+
+## 5. Report
+
+One short block: `gh` and its scopes, what is built in, present companions on one line,
+missing ones with what each buys and its command, config status. Finish with the single
+next thing to do, or say the setup is complete and they can run `/issue-to-pr:run <issue>`.

--- a/plugins/issue-to-pr/tests/contract/test_skill-lint.sh
+++ b/plugins/issue-to-pr/tests/contract/test_skill-lint.sh
@@ -203,3 +203,39 @@ test_autonomy_accounts_for_the_drill() {
   assert_not_contains "$(cat "$(skill_md)")" 'exactly three' \
     "the spine's hard rules still assert the three-moment absolute a --drill run breaks"
 }
+
+setup_md() { printf '%s' "$ITP_SCRIPTS/../skills/setup/SKILL.md"; }
+
+# A companion nobody knows about is a companion nobody installs, and the run degrades to its
+# inline fallback in silence. `setup` is the one place that says what each one buys, so a
+# companion the run knows and setup does not is a lie by omission.
+#
+# The first cut of this test guarded each name with `case "$comps" in *"$c"*)` and skipped on
+# no match. With no `set -e` in the harness an unreadable companions.md left `comps` empty, so
+# every name skipped and the test passed against a one-byte setup skill. Both files are read
+# up front and a short read is a failure, not a skip.
+test_setup_walks_every_companion_the_run_knows() {
+  local s c comps
+  [ -f "$(setup_md)" ] || fail "the setup skill is missing"
+  s=$(cat "$(setup_md)")
+  comps=$(cat "$ITP_SCRIPTS/../skills/run/references/companions.md")
+  [ ${#s} -gt 500 ] || fail "the setup skill is too short to be walking anyone through anything"
+  [ ${#comps} -gt 500 ] || fail "companions.md came back short; the comparison would be vacuous"
+  for c in superpowers ponytail humanizer drill deep-research cross-review code-review simplify; do
+    assert_contains "$comps" "$c" "companions.md must still know the $c companion"
+    assert_contains "$s" "$c" "setup must account for the $c companion the run relies on"
+  done
+}
+
+# Preflight already fails on a missing scope, but it fails mid-run, after the user has asked
+# for work. Setup is where that check is cheap and early. Assert the load-bearing strings: a
+# bare `project` was satisfied by "changes their environment for every project" in the prose.
+test_setup_checks_the_hard_requirements_and_installs_nothing() {
+  local s
+  s=$(cat "$(setup_md)")
+  assert_contains "$s" 'gh auth status' "setup must verify the one hard dependency the run has"
+  assert_contains "$s" 'gh auth refresh -s project' \
+    "board mode needs the project scope; setup must print the command that adds it"
+  assert_contains "$s" 'never run' \
+    "setup prints install commands for a human to run; it must say it installs nothing itself"
+}


### PR DESCRIPTION
> **Stacked on #50.** The base branch is `feat/issue-45-drill`, not `main`, because the setup skill's `drill` row describes `--drill`, which lands in that PR. GitHub retargets this to `main` once #50 merges. Merging this first is not possible, which is the point: an earlier revision sat on `main` and advertised a flag that did not exist yet.

## What changed

`companions.md` lists the optional companions and where each one comes from, but only a reader who opens the reference ever sees it. A first-time user installs the plugin, runs it, and gets the inline fallback everywhere without ever learning there was a better path.

`/issue-to-pr:setup` is that missing first step. It checks the one hard requirement (`gh`, logged in, `repo` scope, plus `project` for board mode), reports each companion as present or missing with one line on what it buys and at which step, and prints the install command for each.

It runs none of them. Installing a plugin changes the user's environment for every project, and that is not a call a setup report gets to make.

It also states that `code-review` and `simplify` ship in the CLI itself and warns that the official plugin also named `code-review` is a different thing. That is the exact mistake that cost Step 7 a real reviewer for several releases, so it now sits where someone setting up will read it.

## Prose only, no script

The two probes are `gh auth status` and `claude plugin list`. A script for that would need its own contract tests and buy nothing the model cannot do directly, and this plugin has spent eight releases moving in the other direction.

## Why not plugin dependencies

Claude Code has had a `dependencies` array in `plugin.json` since v2.1.110, with semver ranges and cross-marketplace resolution behind `allowCrossMarketplaceDependenciesOn`. They are hard dependencies: an unsatisfied one disables the dependent plugin. Declaring `ponytail`, `superpowers` and `drill` there would mean issue-to-pr refuses to load for anyone who has not added three third-party marketplaces, which is the opposite of "the pipeline runs standalone". There is no optional or suggested flavour, and nothing at all at the skill level.

## What the review caught

Eight findings, all fixed. Four are worth repeating.

**Two install commands were fiction.** The `codex-collaboration` row printed `/plugin install codex-collaboration@dmitriy-claude-plugins`, then `/codex:setup`, but `/codex:setup` belongs to the separate `codex` plugin from the `openai-codex` marketplace. Following the row verbatim would have produced an unknown command and a silently-degraded Step 4. The row now carries the full order.

**Both new tests were vacuous, demonstrated rather than suspected.** The companion-coverage test guarded each name with a `case` that skipped on no match; with no `set -e` in the harness, an unreadable `companions.md` left the haystack empty, every name skipped, and the test passed against a one-byte setup skill. The scope test asserted the bare string `project`, which the sentence "changes their environment for every project" already satisfied, and stripping every line about scopes left it green. Both now read both files with a length floor and assert load-bearing strings.

**A false negative I would not have thought of.** With a fine-grained PAT or `GH_TOKEN`, `gh auth status` prints no scopes line at all. The skill would have called a working login broken and sent the user to `gh auth refresh`, which does not support token auth. A blank scopes line now reads as unknown, not missing.

**A path that did not resolve.** The skill pointed at `R/../run/references/companions.md`, but `R/` is shorthand defined only inside the run skill. From `skills/setup/` it expands to nothing. It is now a real relative path.

The reviewer also confirmed what was already right: all five `@marketplace` suffixes resolve, and the claim that a missing `project` scope is non-fatal matches `preflight.sh`, which only warns.

## Decisions made autonomously

- Tier `standard`.
- Prose over a probe script.
- The base branch is #50's rather than `main`, so the merge order is enforced by git instead of by remembering.
- The skill points at `companions.md` as the source of truth on any disagreement, rather than duplicating its fallback column.

## Test status

`bash plugins/issue-to-pr/tests/run-tests.sh`: 150 passed, 0 failed, including `test_setup_walks_every_companion_the_run_knows` and `test_setup_checks_the_hard_requirements_and_installs_nothing`.

Closes #46

## From the verify pass

The reviewer re-ran its mutation battery against the rewritten tests: seven mutations that all passed under the old `case`-guard version now fail, including the original vacuous case (companions.md unreadable **and** the setup skill gutted to one byte).

It also found a residual gap inside my own fix for the token-auth false negative, which is the finding worth keeping. Reporting "scopes unknown, carry on" is right about the login and wrong about the consequence: `preflight.sh` and `board-sync.sh` both detect the `project` scope by grepping the classic `Token scopes:` line, so a fine-grained token that genuinely holds project access still reads as missing to them and board sync gets skipped. Setup exists to predict exactly that before the first run, so under-warning there defeats its purpose. It now says both halves.
