### PR TITLE
fix(plugins): declare the Codex dependency, stop calling optional plugins required

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,11 +5,12 @@
   "owner": {
     "name": "Dmitry Yuhanov"
   },
+  "allowCrossMarketplaceDependenciesOn": ["openai-codex"],
   "plugins": [
     {
       "name": "unity-dev",
       "description": "Unity C# development workflow with architecture design, coding guidelines, testing patterns, and specialized review agents",
-      "version": "1.7.3",
+      "version": "1.7.4",
       "author": {
         "name": "Dmitry Yuhanov"
       },
@@ -20,7 +21,7 @@
     {
       "name": "python-dev",
       "description": "Python development workflow with architecture design, coding guidelines, testing patterns, and specialized review agents",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "author": {
         "name": "Dmitry Yuhanov"
       },
@@ -31,7 +32,7 @@
     {
       "name": "typescript-dev",
       "description": "TypeScript development workflow with architecture design, coding guidelines, testing patterns, and specialized review agents",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "author": {
         "name": "Dmitry Yuhanov"
       },
@@ -53,7 +54,7 @@
     {
       "name": "codex-collaboration",
       "description": "Cross-model collaboration between Claude and Codex — sequential drive/validate/act loops and parallel dual review with triage",
-      "version": "1.10.1",
+      "version": "1.11.0",
       "author": {
         "name": "Dmitry Yuhanov"
       },

--- a/plugins/codex-collaboration/.claude-plugin/plugin.json
+++ b/plugins/codex-collaboration/.claude-plugin/plugin.json
@@ -1,5 +1,8 @@
 {
   "name": "codex-collaboration",
-  "version": "1.10.1",
-  "description": "Cross-model collaboration between Claude and Codex — sequential drive/validate/act loops and parallel dual review with triage"
+  "version": "1.11.0",
+  "description": "Cross-model collaboration between Claude and Codex — sequential drive/validate/act loops and parallel dual review with triage",
+  "dependencies": [
+    { "name": "codex", "marketplace": "openai-codex" }
+  ]
 }

--- a/plugins/codex-collaboration/CHANGELOG.md
+++ b/plugins/codex-collaboration/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the **codex-collaboration** plugin will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.11.0] - 2026-08-28
+
+### Added
+- Declare the Codex plugin as a manifest dependency so it installs with this one; the workflows need both models and have no Claude-only mode
+
 ## [1.10.1] - 2026-07-13
 
 ### Added

--- a/plugins/python-dev/.claude-plugin/plugin.json
+++ b/plugins/python-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "python-dev",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Python development workflow with architecture design, coding guidelines, testing patterns, and specialized review agents",
   "author": {
     "name": "Dmitry Yuhanov"

--- a/plugins/python-dev/CHANGELOG.md
+++ b/plugins/python-dev/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the **python-dev** plugin will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.2.3] - 2026-08-28
+
+### Fixed
+- README called `feature-dev` required; the reviewer agent falls back to reviewing directly without it, so it is optional
+
 ## [1.2.2] - 2026-07-13
 
 ### Fixed

--- a/plugins/python-dev/README.md
+++ b/plugins/python-dev/README.md
@@ -16,7 +16,7 @@ This plugin delegates to standard Claude Code plugins for enhanced functionality
 |-------|--------------|---------|
 | `python-reviewer` | `feature-dev:code-reviewer` | General code quality, logic, and bug detection |
 
-**Required plugins** (install from official marketplace):
+**Optional plugins** (install from the official marketplace). Each agent falls back to reviewing directly when they are absent:
 
 ```bash
 /plugin install feature-dev

--- a/plugins/typescript-dev/.claude-plugin/plugin.json
+++ b/plugins/typescript-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-dev",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "TypeScript development workflow with architecture design, coding guidelines, testing patterns, and specialized review agents",
   "author": {
     "name": "Dmitry Yuhanov"

--- a/plugins/typescript-dev/CHANGELOG.md
+++ b/plugins/typescript-dev/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the **typescript-dev** plugin will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.2.3] - 2026-08-28
+
+### Fixed
+- README called `feature-dev` required; the reviewer agent falls back to reviewing directly without it, so it is optional
+
 ## [1.2.2] - 2026-07-13
 
 ### Fixed

--- a/plugins/typescript-dev/README.md
+++ b/plugins/typescript-dev/README.md
@@ -16,7 +16,7 @@ This plugin delegates to standard Claude Code plugins for enhanced functionality
 |-------|--------------|---------|
 | `typescript-reviewer` | `feature-dev:code-reviewer` | General code quality, logic, and bug detection |
 
-**Required plugins** (install from official marketplace):
+**Optional plugins** (install from the official marketplace). Each agent falls back to reviewing directly when they are absent:
 
 ```bash
 /plugin install feature-dev

--- a/plugins/unity-dev/.claude-plugin/plugin.json
+++ b/plugins/unity-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "unity-dev",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "Unity C# development workflow with architecture design, coding guidelines, testing patterns, and specialized review agents",
   "author": {
     "name": "Dmitry Yuhanov"

--- a/plugins/unity-dev/CHANGELOG.md
+++ b/plugins/unity-dev/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the **unity-dev** plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.7.4] - 2026-08-28
+
+### Fixed
+- README called `feature-dev` and `code-simplifier` required; both agents fall back to working directly without them, so they are optional
+
 ## [1.7.3] - 2026-07-13
 
 ### Fixed

--- a/plugins/unity-dev/README.md
+++ b/plugins/unity-dev/README.md
@@ -17,7 +17,7 @@ This plugin delegates to standard Claude Code plugins for enhanced functionality
 | `unity-reviewer` | `feature-dev:code-reviewer` | General code quality, logic, and bug detection |
 | `unity-simplifier` | `code-simplifier:code-simplifier` | General code cleanup after Unity-specific patterns |
 
-**Required plugins** (install from official marketplace):
+**Optional plugins** (install from the official marketplace). Each agent falls back to reviewing directly when they are absent:
 
 ```bash
 /plugin install feature-dev


### PR DESCRIPTION
Audit of how every plugin in this marketplace declares what it needs, after `plugin.json` gained a `dependencies` field with auto-install.

## codex-collaboration now declares the Codex plugin

`collaborative-loop` prints install instructions and aborts when the Codex plugin is missing, and the plugin has no Claude-only mode by design. That is a hard dependency, so it belongs in the manifest:

```json
"dependencies": [{ "name": "codex", "marketplace": "openai-codex" }]
```

Because Codex lives in another marketplace, `marketplace.json` gains `allowCrossMarketplaceDependenciesOn: ["openai-codex"]`. Without that entry the install fails with a `cross-marketplace` error instead of resolving. The Codex entry is a git-backed relative-path source, so auto-install and version resolution work normally.

## Three plugins stop calling optional plugins required

`python-dev`, `typescript-dev`, and `unity-dev` listed `feature-dev` (and `code-simplifier` for Unity) under "Required plugins". Every agent that delegates to them documents a fallback: `python-reviewer`, `typescript-reviewer`, and `unity-reviewer` review directly when `feature-dev` is absent, and `unity-simplifier` applies general simplifications itself without `code-simplifier`. The READMEs now say optional and name the fallback, so nobody installs a plugin they do not need, and no future change mistakes them for hard dependencies and auto-installs them.

## What was checked and left alone

- Every other plugin declares no dependencies and needs none.
- Soft companions stay out of the manifest on purpose: declaring one would auto-install it and take away the graceful degradation.
- `issue-to-pr` is untouched here. Making `superpowers` a hard dependency is planned separately, and it adds `claude-plugins-official` to the allowlist at that point.

https://claude.ai/code/session_018nzjVw13TCuwKq5MwghAKb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Codex Collaboration now automatically installs its required Codex companion plugin.

- **Bug Fixes**
  - Clarified that optional development plugins are not required; agents can work directly when they are unavailable.
  - Updated dependency guidance for Python, TypeScript, and Unity development plugins.

- **Documentation**
  - Added changelog entries describing dependency behavior and fallback support.

- **Chores**
  - Updated plugin versions for Codex Collaboration, Python, TypeScript, and Unity development tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->