### PR TITLE
fix(issue-to-pr): deep-research is the user's command, not the run's (v5.1.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -130,7 +130,7 @@
     {
       "name": "issue-to-pr",
       "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges; cleanup and the issue's auto-close follow only when the change landed in the default branch, and on any other base the run keeps the branch and says why. The board card advances as work moves.",
-      "version": "5.0.0",
+      "version": "5.1.0",
       "author": {
         "name": "Dmitry Yuhanov"
       },

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Drive a single GitHub issue from triage to a merge-ready pull request through a 
 - Opens the PR and stops; once you approve it in-session it squash-merges. Cleanup follows only when the change landed in the default branch: on any other base, or when the landing branch cannot be confirmed, the branch and worktree are kept and the run says why.
 - The PR auto-links the issue (`Closes #N`), which GitHub closes on a merge into the default branch; board cards advance to *in-progress* at branch cut and *in-review* at PR open, with `Done` left to GitHub's merge-time automation.
 - Graceful by default — missing the `project` token scope degrades to link-only, and a failed status write never blocks the PR.
-- Optional `.claude/issue-to-pr/config.md` for board URL, base branch, and test commands (auto-detected when unset); companion skills (`superpowers:*`, `/deep-research`, `/cross-review`, `humanizer`, `ponytail:*`) used if installed, with inline fallbacks otherwise.
+- Optional `.claude/issue-to-pr/config.md` for board URL, base branch, and test commands (auto-detected when unset); companion skills (`superpowers:*`, `/cross-review`, `humanizer`, `ponytail:*`) used if installed, with inline fallbacks otherwise.
 
 [View documentation](./plugins/issue-to-pr/README.md)
 

--- a/plugins/issue-to-pr/.claude-plugin/plugin.json
+++ b/plugins/issue-to-pr/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "issue-to-pr",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp files; the issue auto-closes on merge and the board card advances as work moves.",
   "author": {
     "name": "Dmitry Yuhanov"

--- a/plugins/issue-to-pr/CHANGELOG.md
+++ b/plugins/issue-to-pr/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the **issue-to-pr** plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [5.1.0] - 2026-08-29
+
+### Fixed
+- Stop presenting `deep-research` as something to install or to route Step 2 through: Claude Code ships it and only starts it when you type it yourself, so Step 2 always uses its own research subagent
+
 ## [5.0.0] - 2026-08-28
 
 ### Removed

--- a/plugins/issue-to-pr/README.md
+++ b/plugins/issue-to-pr/README.md
@@ -56,8 +56,9 @@ progress; everything between them scales to the task.
 Run once before your first task. It checks the one hard requirement (`gh`, logged in, with
 the `repo` scope, plus `project` for board mode), reports which companion skills are present
 and what each missing one would sharpen, and prints the install command for each. It changes
-nothing on its own: the commands are yours to run. It also notes that `code-review` and
-`simplify` are built into Claude Code and need no install at all.
+nothing on its own: the commands are yours to run. It also names what Claude Code already
+registers — `code-review`, `simplify`, `/deep-research` — so nobody hunts an install that
+does not exist.
 
 ### Configuration (optional)
 
@@ -82,9 +83,14 @@ again, but the next merge asks for one more gate run before it will land.
 
 Two of the sharpest tools need no install: Claude Code's own `code-review` reviews the
 diff at Step 7, and its `simplify` is one of the two lenses of the Step 8 gate. The CLI
-registers both, so no marketplace is involved. 
+registers both, so no marketplace is involved.
 
-Optional companions that sharpen specific steps: `superpowers:*`, `/deep-research`,
+`/deep-research` is built in too, but it is yours rather than the pipeline's: Claude Code
+only starts it when you type it. Step 2 always uses an `Explore` subagent, which is the
+ordinary path and not a lesser one. Want the deeper sweep? Run `/deep-research` in your own
+turn and hand the summary in.
+
+Optional companions that sharpen specific steps: `superpowers:*`,
 `/cross-review` (from `codex-collaboration`), `humanizer`, and `ponytail` (whose
 `ponytail-review` is the Step 8 deletion lens, and whose lazy mode shapes the design from
 Step 3 on). Each is used if installed, with an inline fallback otherwise.

--- a/plugins/issue-to-pr/skills/run/SKILL.md
+++ b/plugins/issue-to-pr/skills/run/SKILL.md
@@ -39,9 +39,8 @@ One todo per step.
 - **Config** (`.claude/issue-to-pr/config.md`, optional): you read it at Step 0 and resolve the
   base from it (`R/configuration.md`), in the main checkout — it is gitignored and absent in the
   worktree. Gate commands come from it, or from you at Step 6.
-  **Built in, no install:** `code-review` (Step 7), `simplify` (Step 8). **Companions** (if
-  installed, else inline): `superpowers:*`, `/deep-research`, `/cross-review`, `humanizer`,
-  `ponytail:*` — all in `R/companions.md`.
+  **Built in:** `code-review` (Step 7), `simplify` (Step 8). **Companions** (if installed,
+  else inline): `superpowers:*`, `/cross-review`, `humanizer`, `ponytail:*` — `R/companions.md`.
 - **Tier** (`R/tier-matrix.md`): you pick it at Step 1, `standard` unless the issue argues
   otherwise; it routes research depth, design, review level/passes and report length.
 - **Autonomy** (`R/autonomy.md`, read once at Step 0): the ask contract (three contact moments,
@@ -70,9 +69,9 @@ Exit-code dispatch (bad-checkout, stale dir, invalid start-point, exit-3 in-plac
 `R/contracts.md`. Board-mode (the config names one): move the card to *in progress* with the
 backgrounded chain in `R/configuration.md`; a board failure is one reported line, never a stop.
 
-**2. Research** (tier routes it, complex+ with unknowns): `/deep-research` if installed, else an
-`Explore` subagent handed an explicit question list. Either way you get back a ≤150-line summary
-citing `path:line`; the raw file reads stay in its context, not yours.
+**2. Research** (tier routes it, complex+ with unknowns): an `Explore` subagent handed an explicit
+question list. You get back a ≤150-line summary citing `path:line`; the raw file reads stay in its
+context, not yours. `/deep-research` is the user's own command, never yours to start.
 
 **3. Design** (tier routes it). **Ponytail installed → `/ponytail:ponytail full` first**, ledgered:
 design and implementation then run under the ladder. Complex: author a `Workflow` **inline**

--- a/plugins/issue-to-pr/skills/run/references/companions.md
+++ b/plugins/issue-to-pr/skills/run/references/companions.md
@@ -7,7 +7,6 @@ companion silently degrade quality without saying so.
 | Capability | Preferred (if installed) | Inline fallback |
 |---|---|---|
 | Written plan (Step 5) | `superpowers:writing-plans` | Write a short ordered plan (files to touch, test-first steps, gates) before coding. |
-| Codebase research (Step 2, complex) | `/deep-research` for external topics | An `Explore` subagent handed an explicit question list, returning a ≤150-line cited summary. |
 | Design critique (Step 3, complex) | `/cross-review` over the produced design | Adversarially self-critique the design against the code, then revise. |
 | Humanizing human-facing text (Step 9) | `humanizer` | Self-edit the PR body / report to drop AI-tell phrasing; flag that a humanizer pass would help. |
 | Lazy design and build (Steps 3–5) | `ponytail:ponytail full`, set once before the design | Design and build against the same ladder by hand: does this need to exist, does the stdlib or the platform already do it, can it be one line. |
@@ -19,6 +18,11 @@ companion silently degrade quality without saying so.
 `code-review` and `simplify` are **built into Claude Code** — invoke them by bare name, no
 install, no namespace, no `if installed` branch. They carry their own fallbacks when the
 Agent tool is unavailable, and `code-review` sizes its own finder fan-out to the diff.
+
+`deep-research` is built in as well, but it is **not the run's to use**: since 2.1.218 Claude
+Code starts it only when the user types `/deep-research` themselves. There is no branch here
+and no row above, because there is no choice to make. Step 2's `Explore` subagent is simply
+what Step 2 does; a user wanting the deeper sweep runs the command in their own turn.
 
 Step 7 declines `code-review --fix`: a sweep of applied fixes lands past the per-fix re-gate
 and past the confirmed-bug count the escalation ratchet reads. Fix findings yourself, one at

--- a/plugins/issue-to-pr/skills/setup/SKILL.md
+++ b/plugins/issue-to-pr/skills/setup/SKILL.md
@@ -39,6 +39,11 @@ Report the account and the scopes you actually saw, not a summary of them.
 nothing to install and no marketplace involved, and an official plugin also called
 `code-review` is a different thing. Say they are present, so nobody goes looking.
 
+`/deep-research` needs no install either, for a different reason: Claude Code only starts it
+when the user types it, never on Claude's own initiative. Nothing to check, then, and nothing
+the pipeline can call. If they ask where it went, one line: Step 2 uses its own `Explore`
+subagent, and anyone wanting the deeper sweep runs `/deep-research` themselves.
+
 ## 3. The companions
 
 What each one buys the run is in `../run/references/companions.md`, together with the inline
@@ -54,7 +59,6 @@ without them.
 | `humanizer` | `/plugin install humanizer@dmitriy-claude-plugins` |
 | `drill` | `/plugin marketplace add timini/drill-me` then `/plugin install drill@drill-me` |
 | `codex-collaboration` (`/cross-review`) | Codex first: `/plugin marketplace add openai/codex-plugin-cc`, `/plugin install codex@openai-codex`, `/codex:setup`. Then `/plugin install codex-collaboration@dmitriy-claude-plugins` |
-| `/deep-research` | Comes from your own setup or another plugin |
 
 ## 4. The optional config
 

--- a/plugins/issue-to-pr/tests/contract/test_skill-lint.sh
+++ b/plugins/issue-to-pr/tests/contract/test_skill-lint.sh
@@ -122,6 +122,54 @@ test_setup_walks_every_companion_the_run_knows() {
   done
 }
 
+# Twice now a built-in has been advertised as something to install: `code-review` in
+# companions.md, then `deep-research` in three places at once. Every one slipped past the
+# companion-walk test above, which only checks that the NAME appears somewhere. Hence three
+# regions, each a place whose whole meaning is "you have to install this", and all three
+# checked: the first cut of this test read the setup table alone and went green while both
+# READMEs were still wrong.
+#
+# companions.md gets a narrower rule of its own, at the bottom. The blanket one cannot apply
+# there: its Preferred column legitimately holds `code-review` and `simplify` in their own
+# rows, so banning all three would fail on correct prose. `deep-research` is different, and
+# per-name, because it has no preferred-versus-fallback shape to occupy a row with. The
+# `code-review` incident that opens this comment stays unguarded.
+#
+# Regions 2 and 3 are prose, so the rule there is blunt: any mention trips it, a correct one
+# included. Deliberate. A false red costs a minute; a false green shipped this bug twice.
+# Reword the prose or narrow the slice, never delete the check.
+#
+# `verify` is not guarded yet: absent from the plugin, so the entry would be speculative and
+# the substring would go red on prose that merely says "verify". Add it with the Step 8 slot.
+no_builtins() { # region label
+  local c
+  [ -n "$1" ] || fail "$2 came back empty; this check would be vacuous"
+  for c in code-review simplify deep-research; do
+    assert_not_contains "$1" "$c" "$2 offers $c, which Claude Code already registers"
+  done
+}
+
+test_builtins_are_never_listed_as_installable() {
+  no_builtins "$(sed -n '/^| Companion | Install |/,/^$/p' "$(setup_md)")" \
+    "setup's install table"
+  no_builtins "$(sed -n '/^Optional companions/,/^$/p' "$ITP_SCRIPTS/../README.md")" \
+    "the plugin README's optional-companions paragraph"
+  # Slice the repo README by the claim, not a heading. Take neighbouring lines too, or a hard
+  # wrap that pushes the companion names off the matched line defeats the check silently:
+  # the region stays non-empty, so the vacuity guard above still passes.
+  no_builtins "$(grep -B3 -A3 'used if installed' "$ITP_SCRIPTS/../../../README.md")" \
+    "the repo README's companion line"
+
+  # And the companions table itself, for `deep-research` alone: a row there would put the run
+  # back to choosing between it and the subagent, which is the choice it cannot make.
+  local table
+  table=$(sed -n '/^| Capability | Preferred/,/^$/p' \
+    "$ITP_SCRIPTS/../skills/run/references/companions.md")
+  [ -n "$table" ] || fail "the companions table is gone; this check would be vacuous"
+  assert_not_contains "$table" "deep-research" \
+    "companions.md gives deep-research a row, but the run can never start it"
+}
+
 # A missing scope otherwise surfaces mid-run, after the user has asked for work. Setup is where
 # that check is cheap and early. Assert the load-bearing strings: a bare `project` was satisfied
 # by "changes their environment for every project" elsewhere in the prose.


### PR DESCRIPTION
Closes #57

`skills/setup/SKILL.md` told people `/deep-research` "Comes from your own setup or another plugin", and `companions.md` listed it as Step 2's preferred path with an `Explore` subagent as the fallback. The plugin README called it an optional companion "used if installed", and so did the repo README. Four copies, four wrong.

## What is actually true

Claude Code ships it. The CLI changelog under 2.1.218 says so outright: "Changed `/deep-research` to start only when invoked manually; Claude no longer launches it on its own." Nothing between there and 2.1.239 walks that back.

So it is the user's slash command, not the pipeline's tool. A run cannot reach for it under any condition. Step 2 always uses an `Explore` subagent, and someone wanting the deeper sweep types `/deep-research` in their own turn and hands the summary in.

That is a smaller change than it sounds, and a simpler one. Nothing in the pipeline ever tries, so there is no availability to check, no trigger condition to evaluate, and no recovery branch for a workflow that turns out to be missing.

## The design

Five prose locations state the same rule, so all five had to move together, and the shape of the rule decides how much prose each one carries.

- `skills/run/SKILL.md`: `deep-research` leaves the "Built in" list entirely. The run never invokes it, so listing it beside `code-review` and `simplify` would have it inherit the rule those two carry in `companions.md`, "invoke by bare name, no `if installed` branch". Step 2 loses its conditional and gains one sentence saying whose command it is. Net a line shorter, at 178 of the 180-line budget.
- `skills/run/references/companions.md`: the research row leaves the table. Without a user's word there is no preferred-versus-fallback choice to make, and the column header would have had the run report that `deep-research` "would have improved the result", which is the misinformation this fixes.
- `skills/setup/SKILL.md`: the install row goes, and section 2, whose whole job is naming what ships with the CLI, explains why there is nothing to check.
- Both READMEs drop it from their optional-companion lists.

## The test

`test_setup_walks_every_companion_the_run_knows` only checks that each companion's name appears somewhere in the setup skill. That is why this shipped, and why the same defect shipped once before with `code-review`: a false row satisfies it perfectly.

`test_builtins_are_never_listed_as_installable` checks membership instead. It slices three regions whose whole meaning is "you have to install this" (setup's install table, the plugin README's optional paragraph, the repo README's companion line) and asserts no built-in appears in any of them. Each region was mutation-tested separately: revert the file, watch it go red, restore.

The comment on it records what it does not hold. `companions.md` is deliberately out of scope, because its Preferred column legitimately contains `code-review` and `simplify`, so the original `code-review` incident stays unguarded. And regions 2 and 3 are prose, so any mention trips them, a correct one included. That bluntness is deliberate: a false red costs a minute, and a false green has now shipped this twice.

Structural, not a prose pin. v5.0.0 dropped nine exact-English assertions from this file because they went red on rewrites that changed no meaning, and nothing here reintroduces one.

## Decisions made autonomously

- MINOR rather than PATCH. `CLAUDE.md` files prompt changes under MINOR, and Step 2's behaviour changes. The first cut of this branch was 5.0.1 and review argued it up.
- Tier raised from standard to complex partway through. The scope widened to nine files and to keeping one runtime instruction consistent across five documents; twenty review findings across three passes confirmed the first read was wrong.
- `verify` stays out of the guarded set. It appears nowhere in the plugin yet, so the entry would be speculative and a bare substring would go red on prose that merely says "verify". It arrives with #58.
- Three review passes, then stop. The ratchet fired on the third and escalated the level with no pass left to use it. Honoured the cap and logged the contradiction rather than granting myself a fourth.

## Worth knowing at the gate

The third review pass caught a factual error in the first two rounds of this branch, not a wording problem. I had documented the mechanism as "the run reaches `deep-research` through the `Workflow` tool once the user names it". Claude Code forbids that outright. The correction removed a trigger condition, a recovery branch and roughly a paragraph from each of four files, which is why the final diff is smaller than the one the earlier passes reviewed.

## Noticed, not fixed here

- `plugins/issue-to-pr/.claude-plugin/plugin.json` still describes the run as one where "the issue auto-closes on merge and the board card advances as work moves". v5.0.0 corrected that same unconditional claim in both READMEs and in `marketplace.json` and missed the manifest.
- The companion list exists in four copies that drift independently, which is the root cause of this bug landing in three places at once. A single canonical list, or a test that diffs the four against each other, is the fix at the right altitude. Both filed separately rather than smuggled in here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected guidance so built-in capabilities are no longer presented as installable companion tools.
  * Step 2 research now consistently uses codebase exploration; deep research is user-invoked only.

* **Documentation**
  * Updated setup instructions, companion references, and changelog to reflect the revised workflow.

* **Tests**
  * Added checks ensuring built-in capabilities are not listed as installable.

* **Chores**
  * Updated the plugin version to 5.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->