### PR TITLE
feat(issue-to-pr): check an external claim before building on it (v5.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -130,7 +130,7 @@
     {
       "name": "issue-to-pr",
       "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges; cleanup and the issue's auto-close follow only when the change landed in the default branch, and on any other base the run keeps the branch and says why. The board card advances as work moves.",
-      "version": "5.1.0",
+      "version": "5.2.0",
       "author": {
         "name": "Dmitry Yuhanov"
       },

--- a/plugins/issue-to-pr/.claude-plugin/plugin.json
+++ b/plugins/issue-to-pr/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "issue-to-pr",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp files; the issue auto-closes on merge and the board card advances as work moves.",
   "author": {
     "name": "Dmitry Yuhanov"

--- a/plugins/issue-to-pr/CHANGELOG.md
+++ b/plugins/issue-to-pr/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the **issue-to-pr** plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [5.2.0] - 2026-08-30
+
+### Added
+- Check an external claim before building on it, at every tier, and record what settled it in the PR body
+
 ## [5.1.0] - 2026-08-29
 
 ### Fixed

--- a/plugins/issue-to-pr/skills/run/SKILL.md
+++ b/plugins/issue-to-pr/skills/run/SKILL.md
@@ -33,6 +33,7 @@ One todo per step.
 - **Humanizer** runs on 100% of human-facing text (report, PR body, UI strings > 1–2 words)
   regardless of tier — not code/logs/commit subjects. Don't claim "green/passing" without the
   command output. Don't ask what a script or the code can answer.
+- **Check before you lean on it:** a claim about anything outside this repo gets looked up before you build on it, or ledgered as unchecked (`R/autonomy.md`).
 
 ## Config, tier, ask contract
 

--- a/plugins/issue-to-pr/skills/run/references/tier-matrix.md
+++ b/plugins/issue-to-pr/skills/run/references/tier-matrix.md
@@ -10,7 +10,32 @@ moved it. Borderline picks the **higher** tier.
 | Design | - | mini-design in the PR body | design panel, then `/cross-review` |
 | `code-review` level | `low`, 1 pass | `medium`, <=2 passes | `high`, <=3 passes (may raise to `max` on escalation) |
 
-Gates and the security overlay run at every tier, always.
+Gates, the security overlay, and the external-claim check run at every tier, always.
+
+That last one is not the research step wearing a smaller hat. Step 2 is a survey of unknowns
+and only `complex` runs it; this is one lookup for one doubt, and it fires on a `trivial` copy
+change exactly as it does on a design panel. The trigger is not the kind of work but the kind
+of claim: anything about how the world outside this repository behaves that you are about to
+act on and are not sure of. A design, a test, a line of code, a dependency you are picking, a
+command you are about to run, a sentence you are putting in the docs. Then look it up.
+
+What you find goes in the **ledger** (`R/autonomy.md`), never into a design file.
+`<RUN_DIR>/design.md` is not a surface a reader can count on: it exists only on `complex` or
+under `--drill`, and Step 11 prunes it whenever the change landed on the default branch. The
+ledger is the one path that reaches the PR body from every tier. One entry, the whole shape
+`autonomy.md` defines, `kind: auto` because only `auto` entries render: the claim is the
+`question`, what you then did with the answer is the `decision`, and the `rationale` carries
+what you found **and where**. A conclusion with no source reads exactly like the guess this
+rule exists to stop, so the citation is the part that does the work.
+
+A session with no search is not an exemption from the rule, only from the lookup. Ledger it the
+same way, with the `rationale` saying the claim went unchecked and what you assumed instead.
+Building on an unverified assumption is a judgment call like any other, and the merge gate is
+where someone can weigh it.
+
+Any search the session offers, except `/deep-research`, which is never the run's to start
+(`R/companions.md`). Nothing else is named, deliberately: ranking search tools belongs to
+whatever instructions the operator runs under, not to this plugin.
 
 ## Signals, strongest first
 


### PR DESCRIPTION
Closes #59

Step 2's research fires on `complex` and up, and only when there are unknowns. Below that, a task carrying one uncertain API shape guessed at it, and nothing in the run admitted the guess.

## The rule

A claim about anything outside this repository gets looked up before you build on it. One doubt, one lookup, at any tier. It is not the research step demoted: Step 2 is a survey of unknowns, this is a single question you already know you have.

Where it went matters more than the wording. Two corrections to the issue as filed, both found while implementing it.

## Correction one: there is no research row to edit

The issue points at `tier-matrix.md`'s research row. v5.0.0 cut that table to two rows, Design and `code-review` level; research routing survives only in the spine's own parenthetical at Step 2.

That turned out to be the answer rather than an obstacle. The rule holds identically at all three tiers, and a row saying the same thing in three columns is not a matrix row. It went to the spine's hard-rules block instead, next to "don't claim green/passing without the command output", which is the same discipline pointed at a different kind of claim. `tier-matrix.md` gains the detail, reached by a pointer from the rule.

## Correction two: no search tool is named

The issue said Exa MCP ahead of `WebSearch` and `WebFetch`, per the global instructions. Two problems. Exa is not connected in the session that wrote this, so the instruction would have named a tool that may not exist, which is the defect #57 just fixed pointed the other way. And that preference belongs to one operator's `CLAUDE.md`, not to a plugin other people install: naming it makes a third-party tool a dependency of the skill, which this repo already refused to do for review tools.

So the rule says to check the claim and leaves the ranking to whatever instructions the operator runs under. The one exclusion is spelled out: not `/deep-research`, which v5.1.0 established is never the run's to start.

## Where the answer goes

Into the **ledger**, which already exists, already carries `{question, decision, rationale, kind}`, and which Step 9 already renders into the report and the PR body. No new surface, no new machinery.

The first draft said "cite it where the design goes" and that was wrong on two tiers of three: `trivial` has no design at all, and on `complex` the design lives in `<RUN_DIR>/design.md`, which Step 11 prunes. The citation would have been deleted before any reader saw it. The ledger is the only path that reaches the PR body from every tier, and the PR body is what survives cleanup and what the merge gate actually reads.

The entry is `kind: auto`, because only `auto` entries render. Verified against `references/autonomy.md` line 34 for the schema and line 36 for the render rule, rather than assumed, which is the rule this PR adds applied to the PR itself.

A session with no search is not an exemption from the rule, only from the lookup: the claim still gets an entry, with the `rationale` saying it went unchecked and what was assumed instead. Building on an unverified assumption is a judgment call like any other, and the gate is where someone can weigh it.

## Decisions made autonomously

- The rule is a hard rule, not a step. Gates and the security overlay have executable homes; this has no artifact to leave and no command to run, so a step would be ceremony. It sits with the other truth-discipline rules that are enforced by being always in context.
- Unchecked claims take the same route as checked ones. The first cut sent them to the report instead, on the reasoning that a verified fact deserves the better surface. That is backwards: the reader at the merge gate needs the unverified one more, and a `trivial` report is three lines that already owe five other things.
- No test. This is an instruction with no logic behind it, and pinning its English is what this repo's own test file refuses to do after nine such assertions went red on rewrites that changed no meaning. The line budget is already guarded.
- MINOR, not PATCH: new behaviour, non-breaking.

## Worth knowing at the gate

Two review passes ran, which is what `standard` allows, and both found real work: eight findings then six. The second pass's fixes went to this gate without a third review, because the pass cap is the cap and the scope never widened enough to justify re-tiering. The ratchet escalated the level on the last permitted pass, which is a contradiction in `tier-matrix.md` worth its own issue; it is now the second occurrence in one day and both are in the friction log.

`skills/run/SKILL.md` sits at 179 of 180 lines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External claims are now checked before being used in issue-to-PR workflows across all execution tiers.
  * Verification results, or clearly identified unchecked assumptions, are recorded in the workflow’s decision record and pull request.
* **Documentation**
  * Clarified when external-claim checks and additional research are required.
  * Documented how verified claims and lookup citations are recorded.
  * Updated the issue-to-PR plugin to version 5.2.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->