### PR TITLE
fix(issue-to-pr): make two documents tell the truth again (v5.3.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -130,7 +130,7 @@
     {
       "name": "issue-to-pr",
       "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges; cleanup and the issue's auto-close follow only when the change landed in the default branch, and on any other base the run keeps the branch and says why. The board card advances as work moves.",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "author": {
         "name": "Dmitry Yuhanov"
       },

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -93,6 +93,56 @@ for plugin_json in $(echo "$staged_files" | grep -E '^plugins/[^/]+/\.claude-plu
   if [ -n "$marketplace_version" ] && [ "$plugin_version" != "$marketplace_version" ]; then
     sync_errors+=("${plugin_name}: plugin.json=${plugin_version}, marketplace.json=${marketplace_version}")
   fi
+
+  # The description drifts the same way the version does, and for two releases nothing noticed:
+  # issue-to-pr corrected one sentence in three places and left plugin.json, the only copy
+  # Claude Code itself reads, promising the old behaviour. Same loop, same anchoring.
+  plugin_desc=$(git show ":${plugin_json}" 2>/dev/null | awk '
+    /"description"/ {
+      sub(/^[[:space:]]*"description"[[:space:]]*:[[:space:]]*"/, "")
+      sub(/",?$/, "")
+      print; exit
+    }
+  ')
+
+  marketplace_desc=$(echo "$marketplace_content" | awk -v name="$plugin_name" '
+    /"name"/ { found = ($0 ~ "\"" name "\"") }
+    found && /"description"/ {
+      sub(/^[[:space:]]*"description"[[:space:]]*:[[:space:]]*"/, "")
+      sub(/",?$/, "")
+      print; found=0
+    }
+  ')
+
+  # Fail closed, because every silent path here is a way for the two files to drift unnoticed.
+  # A renamed or deleted entry is the worst of them: it takes the version check above down with
+  # it, so a commit can change both fields and report nothing at all. If the version moved, the
+  # plugin has to be findable in the marketplace, and both descriptions have to be readable.
+  # A brand-new plugin has no entry yet and no HEAD manifest to compare against; Check 4 owns
+  # that case and says the right thing about it. Complaining here as well would report a rename
+  # of something that never existed.
+  # Not `$(git show ... | head -c 1)`: this file runs under `set -euo pipefail`, so pipefail
+  # hands the pipeline git's 128 for a path absent from HEAD and the hook dies right here,
+  # rejecting every new-plugin commit with no message at all.
+  if git show "HEAD:${plugin_json}" >/dev/null 2>&1; then
+    plugin_existed=yes
+  else
+    plugin_existed=
+  fi
+
+  if [ -n "$plugin_existed" ] && ! echo "$marketplace_content" | grep -q "\"${plugin_name}\""; then
+    sync_errors+=("${plugin_name}: no entry in ${MARKETPLACE} (renamed or removed?)")
+  elif ! echo "$marketplace_content" | grep -q "\"${plugin_name}\""; then
+    : # new plugin, unregistered - Check 4 reports it
+  elif [ -z "$plugin_desc" ]; then
+    sync_errors+=("${plugin_name}: no description found in ${plugin_json}")
+  elif [ -z "$marketplace_desc" ]; then
+    sync_errors+=("${plugin_name}: entry in ${MARKETPLACE} has no description")
+  elif [ "$plugin_desc" != "$marketplace_desc" ]; then
+    sync_errors+=("${plugin_name}: descriptions differ
+      plugin.json:      ${plugin_desc}
+      marketplace.json: ${marketplace_desc}")
+  fi
 done
 
 # ── Check 3: CHANGELOG.md updated when version bumps ──────────────────
@@ -227,16 +277,20 @@ fi
 if [ ${#sync_errors[@]} -gt 0 ]; then
   has_errors=true
   echo ""
-  echo "ERROR: marketplace.json version mismatch"
+  echo "ERROR: marketplace.json out of sync"
   echo "========================================"
   echo ""
-  echo "The following plugins have mismatched versions between plugin.json and marketplace.json:"
+  echo "These plugins disagree with marketplace.json about their version or their description:"
   echo ""
   for err in "${sync_errors[@]}"; do
     echo "  - ${err}"
   done
   echo ""
-  echo "Fix: update the version in ${MARKETPLACE} to match, then re-stage and commit."
+  echo "Fix: bring the two files into agreement on the field named above, then re-stage."
+  echo "     'descriptions differ' or a version mismatch: edit whichever copy is wrong."
+  echo "     'no description found in plugins/...': add the key to that plugin.json."
+  echo "     'entry ... has no description': add it to ${MARKETPLACE}."
+  echo "     'no entry in ...': the marketplace entry was renamed or deleted. Restore it."
 fi
 
 if [ ${#changelog_errors[@]} -gt 0 ]; then

--- a/.github/workflows/issue-to-pr-tests.yml
+++ b/.github/workflows/issue-to-pr-tests.yml
@@ -11,11 +11,14 @@ on:
     branches: [main]
     paths:
       - 'plugins/issue-to-pr/**'
+      - '.claude-plugin/marketplace.json'
       - '.githooks/pre-commit'
       - '.github/workflows/issue-to-pr-tests.yml'
   pull_request:
     paths:
       - 'plugins/issue-to-pr/**'
+      - '.claude-plugin/marketplace.json'
+      - '.githooks/pre-commit'
       - '.github/workflows/issue-to-pr-tests.yml'
 
 jobs:

--- a/plugins/issue-to-pr/.claude-plugin/plugin.json
+++ b/plugins/issue-to-pr/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "issue-to-pr",
-  "version": "5.2.0",
-  "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges, then deletes the branch, tears down the worktree, and clears the run's temp files; the issue auto-closes on merge and the board card advances as work moves.",
+  "version": "5.3.0",
+  "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges; cleanup and the issue's auto-close follow only when the change landed in the default branch, and on any other base the run keeps the branch and says why. The board card advances as work moves.",
   "author": {
     "name": "Dmitry Yuhanov"
   }

--- a/plugins/issue-to-pr/CHANGELOG.md
+++ b/plugins/issue-to-pr/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the **issue-to-pr** plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [5.3.0] - 2026-08-30
+
+### Fixed
+- Stop promising cleanup and the issue's auto-close unconditionally in the plugin's description; both wait for a merge into the default branch
+
+### Changed
+- Say in the report when a review pass ran out with fixes still unread, instead of arriving at the merge gate as though everything had been reviewed
+
 ## [5.2.0] - 2026-08-30
 
 ### Added

--- a/plugins/issue-to-pr/scripts/worktree.sh
+++ b/plugins/issue-to-pr/scripts/worktree.sh
@@ -356,8 +356,8 @@ cmd_merge() {
 
   # WHERE it merged, not just that it did: a PR stacked on another feature branch
   # merges into that branch, leaving the issue open and the work off the default one.
-  # One call for both fields, one field per line - the same batching preflight's repo
-  # read uses, and for the same reason.
+  # One call for both fields, one field per line: two gh round-trips for two strings is
+  # the kind of cost that adds up on a step that already makes four.
   mapfile -t _pr_fields < <(gh pr view "$branch" --json url,baseRefName --jq '.url, .baseRefName' 2>/dev/null)
   pr_url=${_pr_fields[0]:-}
   base_ref=${_pr_fields[1]:-}

--- a/plugins/issue-to-pr/skills/run/SKILL.md
+++ b/plugins/issue-to-pr/skills/run/SKILL.md
@@ -33,7 +33,7 @@ One todo per step.
 - **Humanizer** runs on 100% of human-facing text (report, PR body, UI strings > 1–2 words)
   regardless of tier — not code/logs/commit subjects. Don't claim "green/passing" without the
   command output. Don't ask what a script or the code can answer.
-- **Check before you lean on it:** a claim about anything outside this repo gets looked up before you build on it, or ledgered as unchecked (`R/autonomy.md`).
+- **Check before you lean on it:** a claim about anything outside this repo gets looked up before you build on it, and ledgered either way (`R/autonomy.md`).
 
 ## Config, tier, ask contract
 
@@ -68,7 +68,7 @@ own run. Then `S/worktree.sh ensure <N> --branch feat|fix/issue-<N>-<slug> --sta
 as a **literal** (Step 6's rule) and run it through `run-gates.sh` (`--log-dir` on every call).
 Exit-code dispatch (bad-checkout, stale dir, invalid start-point, exit-3 in-place fallback):
 `R/contracts.md`. Board-mode (the config names one): move the card to *in progress* with the
-backgrounded chain in `R/configuration.md`; a board failure is one reported line, never a stop.
+chain in `R/board.md`; a board failure is one reported line, never a stop.
 
 **2. Research** (tier routes it, complex+ with unknowns): an `Explore` subagent handed an explicit
 question list. You get back a ≤150-line summary citing `path:line`; the raw file reads stay in its

--- a/plugins/issue-to-pr/skills/run/references/autonomy.md
+++ b/plugins/issue-to-pr/skills/run/references/autonomy.md
@@ -10,8 +10,9 @@ Contact the user at these three points, and at a fourth only if asked (below):
 1. **Step 4 checkpoint** — ONE batched `AskUserQuestion`, only if the ledger has open
    `asked` items. This is the single mid-run question.
 2. **The merge gate** (Step 10) — always.
-3. **A hard stop** — an exit-2 with no safe default (e.g. `WARN_CLAIMED_BY`, a
-   gate-critical unknown).
+3. **A hard stop** — anything with no safe default: an exit-2 (`WARN_CLAIMED_BY`, a
+   gate-critical unknown), or a preference-bound choice that surfaced too late for
+   moment (1). The checkpoint being spent is not a licence to decide it alone.
 
 A question is for the user (`kind: asked`) only when it is:
 
@@ -35,6 +36,41 @@ Keep one entry per judgment call: `{question, decision, rationale, kind: asked|a
 written down **before the next tool call**, so a compaction cannot lose it. Render the
 `auto` entries as a **"Decisions made autonomously"** section in the Step 9 report AND
 the PR body — the human reviews them at the merge gate they already attend.
+
+## Two things that always earn an entry
+
+Both are `kind: auto`, and only `auto` entries render, so the wrong `kind` means the entry never
+reaches the PR body at all. Neither replaces an `asked` item: where the contract above reserves a
+choice for the human — a new **external** dependency or license is the usual one — the entry
+records the evidence and the choice still goes to them, at Step 4 before the checkpoint and as a
+hard stop after it. Checking is what makes that question worth asking, never a way to skip it.
+
+**A claim about the world outside this repo that you have not checked.** Before building on how
+something outside it behaves while unsure of it, look it up: a design, a test, a line of code, a
+command about to run, a sentence going into the docs. Any tier, and one lookup for one doubt:
+Step 2's survey of unknowns is a different thing and only `complex` runs it. The `question` is
+the claim, the `decision` is what you built on it, and the `rationale` carries what you found
+**and where** — a conclusion with no source reads exactly like the guess this rule exists to
+stop.
+
+It goes here and **never into a design file**. `<RUN_DIR>/design.md` exists only on `complex` or
+under `--drill`, and Step 11 prunes it once the change lands on the default branch, so a citation
+left there is deleted before any reader sees it. The ledger is the one path that reaches the PR
+body from every tier.
+
+Use whatever search the session offers, except `/deep-research` (`R/companions.md`). Nothing else
+is named, deliberately, because ranking search tools belongs to the operator's own instructions.
+No search at all is an exemption from the lookup and never from the entry: say in the `rationale`
+that the claim went unchecked, and what you assumed instead.
+
+**Work no reviewer saw.** The last review pass a tier allows changed something, or Step 8 applied
+a cut after the loop had closed: either way it reaches the merge gate unread. This is **not**
+gated on the ratchet, which needs two confirmed bugs; one bug on the final pass leaves its fix
+exactly as unread. The `question` is what went unreviewed, the `decision` is that you stopped
+rather than overrunning the cap, the `rationale` names the files so the reader knows where to
+look hardest. Say it whatever the tier: a `trivial` report is three lines and this is worth one
+of them. File it when it applies and not otherwise, since a caveat attached to every run is one
+nobody reads.
 
 ## Resume after an interruption
 

--- a/plugins/issue-to-pr/skills/run/references/board.md
+++ b/plugins/issue-to-pr/skills/run/references/board.md
@@ -1,0 +1,47 @@
+# Board sync — GitHub Projects v2
+
+Read only when the config names `board.url` (`R/configuration.md`). Everything here is
+**best-effort at every step**: any failure is one reported line and the run continues. A
+board hiccup never blocks the pipeline, and nothing here is worth debugging mid-run.
+
+`gh auth status` must list the `project` scope. Without it, say once that board sync is off
+and carry on with plain issues; the fix is `gh auth refresh -s project`. A fine-grained token
+prints no scopes line at all — that is unknown, not missing, and board sync is skipped either
+way, because `gh` reads the classic line.
+
+Discovery is **one backgrounded command**, so it costs the run no wait, and it prints what it
+found because a later Bash call is a new shell in which nothing it assigned survives. The
+mutation cannot join it: picking the option needs `opts` in front of you and the matching
+below is a judgement, not a pipeline stage.
+
+```bash
+item=$(gh api graphql -f query='query($owner:String!,$repo:String!,$num:Int!){repository(owner:$owner,name:$repo){issue(number:$num){projectItems(first:20){nodes{id project{id url}}}}}}' \
+  -F owner=<OWNER> -F repo=<REPO> -F num=<N> \
+  --jq '[.data.repository.issue.projectItems.nodes[] | select("<BOARD_URL>"=="" or .project.url=="<BOARD_URL>") | "\(.id)\t\(.project.id)"] | first // ""') \
+  || { echo "BOARD=lookup-failed"; exit 0; }
+[ -n "$item" ] || { echo "BOARD=not-on-the-board"; exit 0; }
+opts=$(gh api graphql -f query='query($proj:ID!,$field:String!){node(id:$proj){... on ProjectV2 {field(name:$field){... on ProjectV2SingleSelectField {id options{id name}}}}}}' \
+  -F proj="${item#*$'\t'}" -F field=Status \
+  --jq '.data.node.field as $f | $f.options[] | "\($f.id)\t\(.name)\t\(.id)"') \
+  || { echo "BOARD=status-unreadable"; exit 0; }
+printf 'ITEM=%s\nOPTS=%s\n' "$item" "$opts"
+```
+
+A failed call leaves on its own rung, which is what lets the next paragraph read an empty
+`opts` as an answer. Twenty items is the whole search: an issue carried on more boards than
+that reads as not on this one, and that is the trade, not an oversight.
+
+`opts` empty means the board has no `Status` field at all, which is not the same as a Status
+field with no matching column — say which one it was. Otherwise pick the option: `status_map`
+pins the exact column name and is authoritative when set; without it match case- and
+punctuation-insensitively against the target, where *in progress* also answers to doing,
+started, wip, in development, and *in review* to review, reviewing, code review, pr open,
+ready for review. Then set it:
+
+```bash
+gh api graphql -f query='mutation($proj:ID!,$item:ID!,$field:ID!,$opt:String!){updateProjectV2ItemFieldValue(input:{projectId:$proj,itemId:$item,fieldId:$field,value:{singleSelectOptionId:$opt}}){projectV2Item{id}}}' \
+  -F proj=<PROJECT_ID> -F item=<ITEM_ID> -F field=<FIELD_ID> -F opt=<OPTION_ID>
+```
+
+`Done` is never set here: GitHub's own automation moves the card when the PR merges into the
+default branch.

--- a/plugins/issue-to-pr/skills/run/references/configuration.md
+++ b/plugins/issue-to-pr/skills/run/references/configuration.md
@@ -1,4 +1,4 @@
-# Step 0 — the config, the base, and the board
+# Step 0 — the config, the base, and claiming the issue
 
 Everything here resolves against the **main checkout**, never a worktree. The config is
 usually untracked, so a worktree has no copy of it, and on a resume you are standing in one.
@@ -82,38 +82,5 @@ another reason. Report them; a warning nobody prints is a warning that was never
 
 ## The board
 
-Only when the config names `board.url`. It is **best-effort at every step**: any failure is
-reported in one line and the run continues. A board hiccup never blocks the pipeline, and
-nothing here is worth debugging mid-run.
-
-`gh auth status` must list the `project` scope. Without it, say once that board sync is off
-and carry on with plain issues; the fix is `gh auth refresh -s project`. A fine-grained token
-prints no scopes line at all — that is unknown, not missing, and board sync is skipped either
-way, because `gh` reads the classic line.
-
-Run the whole chain as **one backgrounded command**, so it costs the run no wait:
-
-```bash
-item=$(gh api graphql -f query='query($owner:String!,$repo:String!,$num:Int!){repository(owner:$owner,name:$repo){issue(number:$num){projectItems(first:20){nodes{id project{id url}}}}}}' \
-  -F owner=<OWNER> -F repo=<REPO> -F num=<N> \
-  --jq '.data.repository.issue.projectItems.nodes[] | select("<BOARD_URL>"=="" or .project.url=="<BOARD_URL>") | "\(.id)\t\(.project.id)"' | head -1)
-[ -n "$item" ] || { echo "not on the board"; exit 0; }
-opts=$(gh api graphql -f query='query($proj:ID!,$field:String!){node(id:$proj){... on ProjectV2 {field(name:$field){... on ProjectV2SingleSelectField {id options{id name}}}}}}' \
-  -F proj="${item#*$'\t'}" -F field=Status \
-  --jq '.data.node.field as $f | $f.options[] | "\($f.id)\t\(.name)\t\(.id)"')
-```
-
-`opts` empty means the board has no `Status` field at all, which is not the same as a Status
-field with no matching column — say which one it was. Otherwise pick the option: `status_map`
-pins the exact column name and is authoritative when set; without it match case- and
-punctuation-insensitively against the target, where *in progress* also answers to doing,
-started, wip, in development, and *in review* to review, reviewing, code review, pr open,
-ready for review. Then set it:
-
-```bash
-gh api graphql -f query='mutation($proj:ID!,$item:ID!,$field:ID!,$opt:String!){updateProjectV2ItemFieldValue(input:{projectId:$proj,itemId:$item,fieldId:$field,value:{singleSelectOptionId:$opt}}){projectV2Item{id}}}' \
-  -F proj=<PROJECT_ID> -F item=<ITEM_ID> -F field=<FIELD_ID> -F opt=<OPTION_ID>
-```
-
-`Done` is never set here: GitHub's own automation moves the card when the PR merges into the
-default branch.
+Only when the config names `board.url`, which most repositories never do. The scopes, the
+three GraphQL calls and the column matching are in `R/board.md`; do not open it otherwise.

--- a/plugins/issue-to-pr/skills/run/references/contracts.md
+++ b/plugins/issue-to-pr/skills/run/references/contracts.md
@@ -13,9 +13,9 @@ decision. This file is the reference: what to call, when, and how to read the re
 - **Uniform exit codes:** `0` proceed · `2` stop-and-ask (reason in `STOP_REASON=`, a hint on
   stderr) · `3` sandbox/permission fallback (do it in place) · `4` degraded (could not parse/reach
   something — do that part by hand). Exceptions noted per script below.
-- Read the config **once in the main checkout** at Step 0 (`R/configuration.md`) and carry the
-  resolved values; never re-read it from inside the worktree. It lives in `.claude/issue-to-pr/`,
-  ignored by a rule the plugin puts there itself, so a worktree normally has no copy at all.
+- Read the config **once in the main checkout** at Step 0 (`R/configuration.md`, which says where
+  it lives and why a worktree has no copy) and carry the resolved values; never re-read it from
+  inside the worktree.
 
 On a stop, `worktree.sh` emits the raw failure alongside `STOP_REASON`: `ADD_ERROR`,
 `DIRTY_FILES`, `PUSH_ERROR`, `MERGE_ERROR`. Read whichever is present and report it
@@ -42,9 +42,8 @@ per rung. The merge carries `--match-head-commit`, so GitHub itself refuses if t
 between the read and the merge. Keys: `MERGED MERGE_METHOD MERGED_INTO BASE_IS_DEFAULT ISSUE_STATE PR_URL` (+
 `FAILING_CHECKS`, `LADDER_STEP`, `WARN_NON_DEFAULT_BASE`). **`BASE_IS_DEFAULT` reads `true` only
 when the landing branch is proved to be the default one** — `false` when the PR merged into
-another feature branch, `unknown` when a ref could not be read. On anything but `true` the issue
-stays open and the work has not reached the default branch, so Step 11 must not treat the task as
-finished. Stops: `pr-head-unreadable · gates-unverified · review-blocked ·
+another feature branch, `unknown` when a ref could not be read. Step 11 owns what each of the
+three means for cleanup. Stops: `pr-head-unreadable · gates-unverified · review-blocked ·
 review-unreadable · push-rejected · checks-failed · merge-conflict · update-branch-failed ·
 base-update-unverified · content-changed-needs-reapproval · checks-pending ·
 merge-ladder-exhausted · merge-failed` — the model's response to each rung is in `merge-ladder.md`.

--- a/plugins/issue-to-pr/skills/run/references/tier-matrix.md
+++ b/plugins/issue-to-pr/skills/run/references/tier-matrix.md
@@ -10,32 +10,9 @@ moved it. Borderline picks the **higher** tier.
 | Design | - | mini-design in the PR body | design panel, then `/cross-review` |
 | `code-review` level | `low`, 1 pass | `medium`, <=2 passes | `high`, <=3 passes (may raise to `max` on escalation) |
 
-Gates, the security overlay, and the external-claim check run at every tier, always.
-
-That last one is not the research step wearing a smaller hat. Step 2 is a survey of unknowns
-and only `complex` runs it; this is one lookup for one doubt, and it fires on a `trivial` copy
-change exactly as it does on a design panel. The trigger is not the kind of work but the kind
-of claim: anything about how the world outside this repository behaves that you are about to
-act on and are not sure of. A design, a test, a line of code, a dependency you are picking, a
-command you are about to run, a sentence you are putting in the docs. Then look it up.
-
-What you find goes in the **ledger** (`R/autonomy.md`), never into a design file.
-`<RUN_DIR>/design.md` is not a surface a reader can count on: it exists only on `complex` or
-under `--drill`, and Step 11 prunes it whenever the change landed on the default branch. The
-ledger is the one path that reaches the PR body from every tier. One entry, the whole shape
-`autonomy.md` defines, `kind: auto` because only `auto` entries render: the claim is the
-`question`, what you then did with the answer is the `decision`, and the `rationale` carries
-what you found **and where**. A conclusion with no source reads exactly like the guess this
-rule exists to stop, so the citation is the part that does the work.
-
-A session with no search is not an exemption from the rule, only from the lookup. Ledger it the
-same way, with the `rationale` saying the claim went unchecked and what you assumed instead.
-Building on an unverified assumption is a judgment call like any other, and the merge gate is
-where someone can weigh it.
-
-Any search the session offers, except `/deep-research`, which is never the run's to start
-(`R/companions.md`). Nothing else is named, deliberately: ranking search tools belongs to
-whatever instructions the operator runs under, not to this plugin.
+Gates, the security overlay, and the external-claim check run at every tier, always. That last
+one scales to nothing at all, so it lives in `R/autonomy.md` with the other ledger rules rather
+than in a table whose three columns would say the same thing.
 
 ## Signals, strongest first
 
@@ -50,7 +27,13 @@ tiers on the wider scope.
 ## Escalation ratchet (one-way)
 
 Count CONFIRMED `code-review` verdicts per pass, and consecutive failures per gate. When
-**2+ confirmed bugs land in one review pass**, or **the same gate fails twice**, escalate
-the review level one notch (never down). A `trivial` run becomes `standard`, which is what
-gives it a design step to re-enter; the matrix grants trivial no design of its own. Report
-the raw per-pass counts at Step 9 so a missed ratchet is visible at the merge gate.
+**2+ confirmed bugs land in one review pass**, or **the same gate fails twice**, escalate the
+review level one notch (never down). A `trivial` run becomes `standard`, which raises the cap
+along with the tier and gives it a design step to re-enter; raising a level inside a tier buys
+no extra pass. Report the raw per-pass counts at Step 9 so a missed ratchet is visible at the
+merge gate.
+
+The cap is the cap. Another pass is how a review loop stops terminating, and the human at the
+merge gate is the backstop this pipeline is built on. So stop, and ledger what stopping cost —
+the entry's shape, and the fact that it is owed whether or not the ratchet ever fired, are in
+`R/autonomy.md` under "Work no reviewer saw".

--- a/plugins/issue-to-pr/tests/contract/test_pre-commit-hook.sh
+++ b/plugins/issue-to-pr/tests/contract/test_pre-commit-hook.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Contract tests for .githooks/pre-commit.
+#
+# The hook is the repo's only guard that fires before a bad commit exists, and the only one
+# covering every plugin rather than this one. Nothing exercised it until now: the suite
+# shellchecks `scripts/*.sh` and the fake gh, and no test ran the hook at all. That gap shipped
+# a description-sync check whose sed had been mangled into a no-op, which guarded nothing.
+#
+# Each test builds a throwaway repo in its own TEST_TMPDIR and drives real `git commit`: what is
+# under test is the hook's behaviour against a real index, not a function in isolation.
+#
+# The fixture carries TWO plugins, with the one under test second, and gives each an
+# `"author": {"name": ...}` the way the real marketplace does. Both details are load-bearing.
+# The hook selects an entry with an awk `found` flag that re-arms on every line containing
+# `"name"`, so a single-plugin fixture with no nested name lets an awk that ignores the plugin
+# name entirely pass every test here while comparing the wrong entry against the real file.
+
+hook_src() { printf '%s' "$ITP_SCRIPTS/../../../.githooks/pre-commit"; }
+
+marketplace_json() { # foo_description
+  cat <<EOF
+{
+  "plugins": [
+    {
+      "name": "aaa-decoy",
+      "description": "A different plugin that sorts first and must never be the one compared.",
+      "version": "9.9.9",
+      "author": { "name": "Someone Else" }
+    },
+    {
+      "name": "foo",
+      "description": "$1",
+      "version": "$2",
+      "author": { "name": "Test" }
+    }
+  ]
+}
+EOF
+}
+
+plugin_json() { # version description
+  cat <<EOF
+{
+  "name": "foo",
+  "version": "$1",
+  "description": "$2",
+  "author": { "name": "Test" }
+}
+EOF
+}
+
+# A repo with two registered plugins, `foo` committed at 1.0.0, hook installed. Leaves cwd in it.
+fixture_repo() { # foo_description
+  local desc=${1:?description}
+  [ -f "$(hook_src)" ] || fail "the hook is missing at $(hook_src)"
+
+  git init -q .
+  git config user.email t@example.com
+  git config user.name Test
+  git config core.hooksPath .githooks
+  git config commit.gpgsign false
+
+  mkdir -p .githooks .claude-plugin plugins/foo/.claude-plugin plugins/aaa-decoy/.claude-plugin
+  cp "$(hook_src)" .githooks/pre-commit
+  chmod +x .githooks/pre-commit
+
+  plugin_json 1.0.0 "$desc" > plugins/foo/.claude-plugin/plugin.json
+  printf '# Changelog\n\n## [1.0.0] - 2026-01-01\n\n### Added\n- first\n' > plugins/foo/CHANGELOG.md
+  printf '{\n  "name": "aaa-decoy",\n  "version": "9.9.9",\n  "description": "A different plugin that sorts first and must never be the one compared.",\n  "author": { "name": "Someone Else" }\n}\n' \
+    > plugins/aaa-decoy/.claude-plugin/plugin.json
+  printf '# Changelog\n\n## [9.9.9] - 2026-01-01\n\n### Added\n- decoy\n' > plugins/aaa-decoy/CHANGELOG.md
+  marketplace_json "$desc" 1.0.0 > .claude-plugin/marketplace.json
+  printf '# Repo\n\nfoo, aaa-decoy\n' > README.md
+
+  git add -A
+  git commit -q --no-verify -m seed
+}
+
+# Stage a version bump for `foo` with its changelog entry, so only the field under test can fail.
+stage_bump() { # plugin_description marketplace_description
+  plugin_json 1.1.0 "$1" > plugins/foo/.claude-plugin/plugin.json
+  marketplace_json "$2" 1.1.0 > .claude-plugin/marketplace.json
+  printf '# Changelog\n\n## [1.1.0] - 2026-01-02\n\n### Changed\n- second\n\n## [1.0.0] - 2026-01-01\n\n### Added\n- first\n' \
+    > plugins/foo/CHANGELOG.md
+  git add -A
+}
+
+# `git commit` must fail, and fail for the stated reason. Asserting only that it exited non-zero
+# passes on any unrelated hook error, which is how a guard ends up proving nothing.
+# The trailing `case` also gives the function its exit status: the harness runs tests without
+# `set -e`, so whatever runs last decides, and an `&&` list must never be that last thing.
+refuse_commit() { # message reason_substring
+  local out
+  if out=$(git commit -m "${1}" 2>&1); then
+    fail "the hook allowed the commit it had to stop:
+$out"
+  fi
+  case "$out" in
+    *"$2"*) : ;;
+    *) fail "rejected, but not for '$2'. Got:
+$out" ;;
+  esac
+}
+
+test_hook_rejects_a_description_that_drifted_from_the_marketplace() {
+  fixture_repo "Does the original thing."
+  stage_bump "Does the NEW thing." "Does the original thing."
+  refuse_commit drift "descriptions differ"
+}
+
+# Fail closed. A renamed entry used to take the version check down with it, so a commit could
+# change both fields and report nothing at all.
+test_hook_rejects_a_marketplace_entry_that_no_longer_answers_to_the_name() {
+  fixture_repo "Does the original thing."
+  stage_bump "Does the NEW thing." "Does the NEW thing."
+  sed -i 's/"name": "foo"/"name": "foo-renamed"/' .claude-plugin/marketplace.json
+  git add -A
+  refuse_commit renamed "no entry in"
+}
+
+# Both sides empty compare equal, which is the one path that would sail through in silence.
+test_hook_rejects_a_plugin_manifest_with_no_description_at_all() {
+  fixture_repo "Does the original thing."
+  stage_bump "Does the NEW thing." "Does the NEW thing."
+  printf '{\n  "name": "foo",\n  "version": "1.1.0",\n  "author": { "name": "Test" }\n}\n' \
+    > plugins/foo/.claude-plugin/plugin.json
+  sed -i '/"description": "Does the NEW thing."/d' .claude-plugin/marketplace.json
+  git add -A
+  refuse_commit stripped "no description found"
+}
+
+# The guard has to let real work through, or it gets bypassed with --no-verify and guards nothing.
+# This is also the test that kills an entry-selection bug: with `foo` second in the marketplace,
+# an extraction that ignores the name compares aaa-decoy's description here and goes red.
+test_hook_accepts_a_bump_whose_manifests_agree() {
+  local out
+  fixture_repo "Does the original thing."
+  stage_bump "Does the NEW thing." "Does the NEW thing."
+
+  out=$(git commit -m agreed 2>&1) || fail "the hook blocked a correct commit:
+$out"
+  git log --oneline | grep -q agreed || fail "commit reported success but nothing landed"
+}
+
+# A brand-new plugin has no marketplace entry yet and no manifest in HEAD. Check 4 owns that and
+# says the right thing; the sync check must stay quiet rather than report a rename of something
+# that never existed. This branch shipped once already saying exactly that.
+test_hook_leaves_an_unregistered_new_plugin_to_check_4() {
+  local out
+  fixture_repo "Does the original thing."
+
+  mkdir -p plugins/newthing/.claude-plugin
+  printf '{\n  "name": "newthing",\n  "version": "1.0.0",\n  "description": "Brand new."\n}\n' \
+    > plugins/newthing/.claude-plugin/plugin.json
+  printf '# Changelog\n\n## [1.0.0] - 2026-01-02\n\n### Added\n- first\n' > plugins/newthing/CHANGELOG.md
+  git add -A
+
+  if out=$(git commit -m newplugin 2>&1); then
+    fail "an unregistered new plugin was allowed through:
+$out"
+  fi
+  # Demand Check 4's own words. "It exited non-zero" also describes the hook dying on an
+  # unguarded `set -e`, which is exactly how the first cut of this branch failed: every
+  # new-plugin commit was rejected with no message at all, and a laxer assertion passed on it.
+  case "$out" in
+    *"New plugin missing from marketplace.json"*) : ;;
+    *) fail "rejected, but Check 4 never spoke. Got:
+$out" ;;
+  esac
+  case "$out" in
+    *"no entry in"*) fail "the sync check reported a rename of a plugin that never had an entry:
+$out" ;;
+  esac
+}

--- a/plugins/issue-to-pr/tests/contract/test_skill-lint.sh
+++ b/plugins/issue-to-pr/tests/contract/test_skill-lint.sh
@@ -182,3 +182,37 @@ test_setup_checks_the_hard_requirements_and_installs_nothing() {
   assert_contains "$s" 'never run' \
     "setup prints install commands for a human to run; it must say it installs nothing itself"
 }
+
+# v5.0.0 corrected one sentence about cleanup in three places and missed the fourth: the plugin
+# manifest, which is the only copy Claude Code itself reads. It stayed wrong for two releases
+# because the pre-commit hook keeps the two manifests' VERSIONS in step and says nothing about
+# what they claim the plugin does. Byte equality is the whole rule. If they ever have to differ,
+# change this test and say why in the same commit.
+desc_of() { # file [anchor-line]
+  local line
+  if [ -n "${2:-}" ]; then
+    line=$(grep -A1 -F -- "$2" "$1" | grep '"description"' | head -1)
+  else
+    line=$(grep '"description"' "$1" | head -1)
+  fi
+  line=${line#*\"description\": \"}
+  line=${line%\",}
+  printf '%s' "${line%\"}"
+}
+
+test_manifests_agree_on_what_the_plugin_does() {
+  local plugin market
+  plugin=$(desc_of "$ITP_SCRIPTS/../.claude-plugin/plugin.json")
+  market=$(desc_of "$ITP_SCRIPTS/../../../.claude-plugin/marketplace.json" '"name": "issue-to-pr"')
+  # Guard the extraction, not its length: a byte count is a proxy that goes red on a legitimately
+  # shorter description, and gets "fixed" by lowering the number. What must hold is that the
+  # prefix strip fired and something came back.
+  [ -n "$plugin" ] || fail "no description found in plugin.json; this check would be vacuous"
+  [ -n "$market" ] || fail "no issue-to-pr description found in marketplace.json; check vacuous"
+  case "$plugin$market" in
+    *'"description"'*) fail "the key survived the strip, so both sides are raw lines; check vacuous" ;;
+  esac
+  [ "$plugin" = "$market" ] || fail "the manifests describe the plugin differently:
+    plugin.json:      $plugin
+    marketplace.json: $market"
+}


### PR DESCRIPTION
Closes #60
Closes #63

Two issues, one theme, which is why they share a PR: a document promising what the code does not do.

## #60: the manifest

`plugin.json` still described the run as one that "deletes the branch, tears down the worktree, and clears the run's temp files; the issue auto-closes on merge". v5.0.0 made cleanup and the auto-close conditional on landing in the default branch, corrected that sentence in both READMEs and in `marketplace.json`, and missed the manifest. Which is the only copy Claude Code itself reads.

It now matches `marketplace.json` byte for byte.

## #63: the escalation with nothing to spend

The pass cap and the ratchet collide on the last pass a tier allows: the ratchet raises a level no remaining pass will apply, and the fixes that pass asked for reach the merge gate unread. Both #57 and #59 hit it on the same day.

The cap wins. Another pass is how a review loop stops terminating, and the human at the gate is the backstop this pipeline is built on. What changes is that stopping now costs a ledger entry, so it reaches the PR body instead of dying in the session's scrollback.

Two corrections during review shaped it more than the original decision did:

- **The trigger is not the ratchet.** It needs two confirmed bugs; one bug on the final pass leaves its fix unreviewed exactly the same way, and that is the commoner case. The trigger is now simply that the last permitted pass changed something and nothing came after it.
- **Step 8 owes the same entry.** Its cuts land after the review loop and are never re-reviewed, so a cut accepted there arrives unread even on a run whose last review pass was clean.

## The guard moved to where it belongs

`.githooks/pre-commit` already kept the two manifests' versions in step and said nothing about their descriptions. That is how the drift survived two releases. It now compares both, for all thirteen plugins, before a bad commit exists rather than after.

It fails closed. An empty extraction is not agreement, and a renamed or deleted marketplace entry used to silence the version check too, so a commit could change both fields and report nothing at all. A brand-new plugin is left to Check 4, which already says the right thing about it.

## The tests

`test_pre-commit-hook.sh` is the first test in this repo to run the hook at all. Five cases, each building a throwaway repo and driving a real `git commit`.

Two details of the fixture are load-bearing and the comment says so: it carries **two** plugins with the target **second**, and gives each a nested `"author": {"name": ...}`. Review mutation-tested the first draft and found a survivor. An extraction that ignores the plugin name entirely, always returning the first entry's description, passed every test against a single-plugin fixture. It now goes red.

`test_manifests_agree_on_what_the_plugin_does` stays in the skill-lint suite as well, and the redundancy is deliberate: the hook is bypassable with `--no-verify`, absent on a fresh clone until `core.hooksPath` is set, and never runs on a GitHub web edit. `.claude-plugin/marketplace.json` joins the CI path filter for the same reason.

## What went wrong on the way, since it is the most useful part

The first cut of the brand-new-plugin guard read `plugin_existed=$(git show "HEAD:$plugin_json" 2>/dev/null | head -c 1)`. Under this hook's `set -euo pipefail`, `pipefail` hands the pipeline git's 128 for a path absent from HEAD, and the hook dies right there. Every new-plugin commit was rejected with **no message at all**.

The test written for that branch passed anyway, because it asserted only that the commit failed and that the output lacked one particular phrase. Both hold perfectly when there is no output. What caught it was not reading the code but mutation: the test returned the same result with the guard present and removed, which means it measured nothing.

That test now demands Check 4's own words, and both mutants die.

## Decisions made autonomously

- Batched #60 and #63; kept #61 out. The first two are one theme and small. #61 is the root-cause fix for the four-copy companion list, needs a design choice, and its own issue says not to fold it into another check.
- Scope grew into `.githooks/` and `.github/workflows/` during review. Both are about making this change actually work rather than new territory: the hook is where the check belongs, and without the path filter the new test never runs on the file most likely to break it.
- Re-tiered standard to complex when that happened, which bought a third review pass. On #59 the same day I refused to re-tier because the scope had not widened; here eight files including repo infrastructure and a new test file is a different animal.
- MINOR, not PATCH: a behaviour change in the report contract.

## A prose audit, and what reviewing it found

A release about documents telling the truth should not itself grow what an agent reads before it can start. Measured, then cut.

`tier-matrix.md` had reached 78 lines, of which 47 were not about tiers. The external-claim rule was the worse half: its own justification, written on #59, was that the rule holds identically at all three tiers and therefore is not a matrix row, and the detail went into the matrix anyway. Both ledger rules now live in `autonomy.md`, beside the ledger they write to. `configuration.md` carried 37 lines of Projects v2 GraphQL that every run read at Step 0 and only a board run could use; those moved to `board.md` behind a one-line door.

| read at Step 0-1 | before | after |
|---|---|---|
| `SKILL.md` | 179 | 179 |
| `configuration.md` | 119 | 86 |
| `tier-matrix.md` | 78 | 39 |
| `autonomy.md` | 42 | 78 |
| **total** | **418** | **382** |

The first draft of that audit claimed content was preserved line for line. It was not, and it passed because the claim was checked against six hand-picked phrases. Two review passes plus a full enumeration of all twenty-five moved instructions found nine defects in it:

- **An ask-contract contradiction.** A newly written sentence declared both ledger rules "never a question for the user", twenty lines below a contract reserving a new external dependency or license for the human. A dependency choice would have shipped as an autonomous entry instead of a question.
- **The first fix opened a worse hole.** Routing it to "still ask at Step 4" closes every exit when the claim surfaces mid-implementation: the checkpoint is spent, asking mid-implementation is forbidden, deciding alone is forbidden. The ask contract's third moment now covers a preference-bound choice that surfaced too late for the first, which is where the hole actually lived.
- **An instruction lost outright.** "Goes in the ledger, never into a design file", with its reasoning, existed zero times after the move. On `complex` the natural home for a citation is `design.md`, which Step 11 prunes.
- **A spine line that cancelled the rule.** "Looked up **or** ledgered as unchecked" parses as either/or, so a run could check a claim and file nothing, while the section it points at says the entry is always owed.
- **The rule duplicated rather than moved**, stated twice in two files in different words. That is the drift mechanism this branch is named after.
- Plus `BASE_IS_DEFAULT` explained in both the spine and `contracts.md`; the config's location stated three times; `/deep-research` forbidden in three wordings; and `board.md` inheriting the claim that the whole GraphQL chain runs as one backgrounded command, when its mutation needs a human-judged column match in the middle.

Two of the twenty-five were caught by the enumeration and by neither reviewer: "one lookup for one doubt", and the distinction from Step 2's research without which the rule reads as complex-only.

## At the gate

Three review passes on the main content, finding seven, five and eight, plus two more on the audit finding five and eight.

The main content's third-pass fixes, and the silent-death regression found while verifying them, reached this gate without a fourth review. That is the cap doing its job, and by the rule this PR adds, saying so is not optional. They touched the `plugin_existed` guard and the remediation text in `.githooks/pre-commit`, the trigger and Step 8 clause in `tier-matrix.md`, and `test_pre-commit-hook.sh`.

The audit is not in that category. It was reviewed twice after it was written, so there is nothing to disclose about it.

Step 8 changed nothing on this run, so nothing else arrived unread.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated issue-to-PR plugin guidance for conditional cleanup and issue closure when changes merge into the default branch.
  - Added clearer handling and reporting for incomplete review passes and work not reviewed.
  - Documented best-effort project board synchronization and improved review escalation rules.

- **Documentation**
  - Clarified external-claim verification, stopping rules, board updates, and configuration guidance.

- **Bug Fixes**
  - Improved consistency checks between plugin descriptions and marketplace entries.
  - Updated the plugin to version 5.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->