### PR TITLE
feat(issue-to-pr)!: verify what the PR claims, grill the design (v6.0.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -130,7 +130,7 @@
     {
       "name": "issue-to-pr",
       "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges; cleanup and the issue's auto-close follow only when the change landed in the default branch, and on any other base the run keeps the branch and says why. The board card advances as work moves.",
-      "version": "5.3.0",
+      "version": "6.0.0",
       "author": {
         "name": "Dmitry Yuhanov"
       },

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Drive a single GitHub issue from triage to a merge-ready pull request through a 
 - Opens the PR and stops; once you approve it in-session it squash-merges. Cleanup follows only when the change landed in the default branch: on any other base, or when the landing branch cannot be confirmed, the branch and worktree are kept and the run says why.
 - The PR auto-links the issue (`Closes #N`), which GitHub closes on a merge into the default branch; board cards advance to *in-progress* at branch cut and *in-review* at PR open, with `Done` left to GitHub's merge-time automation.
 - Graceful by default — missing the `project` token scope degrades to link-only, and a failed status write never blocks the PR.
-- Optional `.claude/issue-to-pr/config.md` for board URL, base branch, and test commands (auto-detected when unset); companion skills (`superpowers:*`, `/cross-review`, `humanizer`, `ponytail:*`) used if installed, with inline fallbacks otherwise.
+- Optional `.claude/issue-to-pr/config.md` for board URL, base branch, and test commands (auto-detected when unset); companion skills (`superpowers:*`, `/cross-review`, `humanizer`, `ponytail:*`, `mattpocock-skills:grilling`) used if installed, with inline fallbacks otherwise.
 
 [View documentation](./plugins/issue-to-pr/README.md)
 

--- a/plugins/issue-to-pr/.claude-plugin/plugin.json
+++ b/plugins/issue-to-pr/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "issue-to-pr",
-  "version": "5.3.0",
+  "version": "6.0.0",
   "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges; cleanup and the issue's auto-close follow only when the change landed in the default branch, and on any other base the run keeps the branch and says why. The board card advances as work moves.",
   "author": {
     "name": "Dmitry Yuhanov"

--- a/plugins/issue-to-pr/CHANGELOG.md
+++ b/plugins/issue-to-pr/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the **issue-to-pr** plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [6.0.0] - 2026-08-31
+
+### Added
+- Drive the built change at its own surface after the diff settles, so a PR has to do what it says and not only keep the tests green
+
+### Changed
+- `--drill` becomes `--grill`: the checkpoint now interviews you over the design in rounds instead of teaching you a design already made, and it replaces the one batched question rather than adding a fourth interruption
+
+### Removed
+- The `drill-me` marketplace from the setup skill's install table
+
 ## [5.3.0] - 2026-08-30
 
 ### Fixed

--- a/plugins/issue-to-pr/README.md
+++ b/plugins/issue-to-pr/README.md
@@ -17,7 +17,7 @@ as work progresses.
 ### Skill: `run`
 
 Invoked by the model or by you (`/issue-to-pr:run [issue-number | "free text"]
-[--tier trivial|standard|complex] [--drill]`). The pipeline runs triage, research, design,
+[--tier trivial|standard|complex] [--grill]`). The pipeline runs triage, research, design,
 implementation, review, PR, approval-gated merge, and cleanup. Hard gates block forward
 progress; everything between them scales to the task.
 
@@ -29,13 +29,16 @@ progress; everything between them scales to the task.
   and report length all size to it.
 - **Autonomous, one question max.** The skill contacts you at three moments: one
   batched question mid-run (only if something genuinely needs your preference), the merge
-  gate, and hard stops. Pass `--drill` and it adds a fourth on purpose: the `drill` tutor
-  walks you through the design before anything is built, and whatever you dispute there is
-  folded into that same batched question. It makes every other decision itself, logs it, and surfaces it in
-  the report and PR body.
+  gate, and hard stops. Pass `--grill` and the first of those changes shape rather than
+  multiplying: instead of one batched question you get `grilling`, which works the design in
+  rounds of numbered decisions, each with a recommended answer, until nothing is left silently
+  assumed. It makes every other decision itself, logs it, and surfaces it in the report and PR
+  body.
 - **Gates.** Design hardening (cross-review or a multi-agent fallback), tests green
   (typecheck + tests, plus visual checks for UI work), and a code-review loop that runs
   until clean; the review level escalates automatically when passes keep finding real bugs.
+  Once the diff has settled, a last pass builds the change and drives it at its own surface,
+  because green tests are not the same claim as "the thing in the PR title happens".
 - **Beyond a single issue.** A plain request with no number is drafted into an issue and run.
 - **A careful merge gate.** Merge happens only on your explicit in-session approval, never
   on the turn the PR opens. What a script can prove, a script proves: the merge refuses a head
@@ -81,9 +84,10 @@ again, but the next merge asks for one more gate run before it will land.
 
 ### Companion skills (optional)
 
-Two of the sharpest tools need no install: Claude Code's own `code-review` reviews the
-diff at Step 7, and its `simplify` is one of the two lenses of the Step 8 gate. The CLI
-registers both, so no marketplace is involved.
+Three of the sharpest tools need no install: Claude Code's own `code-review` reviews the
+diff at Step 7, its `simplify` is one of the two lenses of the Step 8 gate, and its `verify`
+closes that step by driving the built change. The CLI registers all three, so no marketplace
+is involved.
 
 `/deep-research` is built in too, but it is yours rather than the pipeline's: Claude Code
 only starts it when you type it. Step 2 always uses an `Explore` subagent, which is the
@@ -91,9 +95,10 @@ ordinary path and not a lesser one. Want the deeper sweep? Run `/deep-research` 
 turn and hand the summary in.
 
 Optional companions that sharpen specific steps: `superpowers:*`,
-`/cross-review` (from `codex-collaboration`), `humanizer`, and `ponytail` (whose
-`ponytail-review` is the Step 8 deletion lens, and whose lazy mode shapes the design from
-Step 3 on). Each is used if installed, with an inline fallback otherwise.
+`/cross-review` (from `codex-collaboration`), `humanizer`, `mattpocock-skills` (whose
+`grilling` is what `--grill` runs), and `ponytail` (whose `ponytail-review` is the Step 8
+deletion lens, and whose lazy mode shapes the design from Step 3 on). Each is used if
+installed, with an inline fallback otherwise.
 
 ## Usage
 

--- a/plugins/issue-to-pr/scripts/lib/common.sh
+++ b/plugins/issue-to-pr/scripts/lib/common.sh
@@ -124,7 +124,7 @@ canonical_branch() {
 }
 
 # state_dir ROOT - where everything this plugin writes into a repository lives: the
-# the config, gate receipts, the friction log. One definition, because the path is
+# config, gate receipts, and each run's own files. One definition, because the path is
 # spliced into a receipt name, a config path and an ignore rule that must agree.
 state_dir() { printf '%s/.claude/issue-to-pr' "$1"; }
 

--- a/plugins/issue-to-pr/skills/run/SKILL.md
+++ b/plugins/issue-to-pr/skills/run/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   N", "work on issue #N", "build/fix X" when no issue exists yet, and —
   for the merge gate later — "merge it", "approve the PR", "ship it", "lgtm merge".
 user-invocable: true
-argument-hint: "[issue-number | \"free text\"] [--tier trivial|standard|complex] [--drill]"
+argument-hint: "[issue-number | \"free text\"] [--tier trivial|standard|complex] [--grill]"
 ---
 
 # issue-to-pr — issue → merge-ready PR pipeline
@@ -24,9 +24,9 @@ One todo per step.
   resolved base. All work happens there; never two tasks in one tree.
 - **Merge is gated on explicit in-session approval**, runs ONLY in the main session, via
   `S/worktree.sh merge` — never a bare `gh pr merge`, never on the turn the PR opens.
-- **Ask contract:** three moments, four with `--drill` (`R/autonomy.md`) — (1) ONE batched
-  `AskUserQuestion` at Step 4 (only if the ledger has open items), (2) the merge gate,
-  (3) a hard stop. Decide everything else yourself and log it (see below).
+- **Ask contract:** three moments, `--grill` reshapes the first (`R/autonomy.md`) — (1) Step 4:
+  ONE batched `AskUserQuestion` if the ledger has open items, or the grill in its place, (2) the
+  merge gate, (3) a hard stop. Decide everything else yourself and log it (see below).
 - Stage with **explicit paths** (`git add path1 path2`); never `git add -A`/`.`, which
   sweeps in whatever the project keeps untracked. Conventional Commits. TDD (failing test first) for any logic. Write multi-line
   code with the Write tool — a Bash heredoc breaks on an apostrophe inside the body.
@@ -40,26 +40,25 @@ One todo per step.
 - **Config** (`.claude/issue-to-pr/config.md`, optional): you read it at Step 0 and resolve the
   base from it (`R/configuration.md`), in the main checkout — it is gitignored and absent in the
   worktree. Gate commands come from it, or from you at Step 6.
-  **Built in:** `code-review` (Step 7), `simplify` (Step 8). **Companions** (if installed,
-  else inline): `superpowers:*`, `/cross-review`, `humanizer`, `ponytail:*` — `R/companions.md`.
+  **Built in:** `code-review` (Step 7), `simplify` and `verify` (Step 8). **Companions** (if
+  installed, else inline): `superpowers:*`, `/cross-review`, `humanizer`, `ponytail:*`,
+  `mattpocock-skills:grilling` — `R/companions.md`.
 - **Tier** (`R/tier-matrix.md`): you pick it at Step 1, `standard` unless the issue argues
   otherwise; it routes research depth, design, review level/passes and report length.
-- **Autonomy** (`R/autonomy.md`, read once at Step 0): the ask contract (three contact moments,
-  a fourth only with `--drill`), and the ledger of judgment calls you keep in context and render
-  into the report + PR body.
+- **Autonomy** (`R/autonomy.md`, read once at Step 0): the ledger of judgment calls you keep in
+  context and render into the report + PR body — the ask contract is above.
 
 ## Steps
 
 **0. Resolve.** Turn the request into an issue. Free text with no issue number → draft one that
 restates the request and nothing more, `gh issue create`, and make `Drafted issue #<N>: <title>`
 the **first output line of the turn** — that echo is the only guard against issue spam; ambiguous
-scope → ONE `AskUserQuestion` BEFORE creating it (the run's single question, moved earlier, not a
-fourth). Then work out the ground the run stands on, **in the main checkout**, never a worktree,
+scope → ONE `AskUserQuestion` BEFORE creating it (the run's single question, moved
+earlier). Then work out the ground the run stands on, **in the main checkout**, never a worktree,
 following `R/configuration.md`: `gh auth status` (no auth → stop), `gh repo view`, the config file,
 `<BASE>` and `<START_POINT>`, the gate commands the config names, `gh issue view`, and claim the
 issue. **Report every warning that page tells you to raise** — an unresolved base surfaces there
 and nowhere else. An issue already assigned to someone else is a **hard stop**: ask first.
-`<RUN_DIR>` is `.claude/issue-to-pr/runs/task-<N>/` under the main checkout.
 
 **1. Triage + worktree.** Pick `TIER` against `R/tier-matrix.md`: `standard` unless the issue's
 signals say otherwise, `--tier` pins it; too large for one PR → split into issues first, each its
@@ -80,29 +79,29 @@ design and implementation then run under the ladder. Complex: author a `Workflow
 number, title and context paths written into the script text as literals, never
 passed through `args`. Returns the design (→ `<RUN_DIR>/design.md`) + rejected alternatives; a
 throw or an empty design → design inline. `/cross-review` critiques the result. Preference-bound
-questions → ledger. Standard: a mini-design in the PR body. **`--drill` → write the design to
-`<RUN_DIR>/design.md` whatever the tier**, including trivial: there is nothing to drill otherwise.
+questions → ledger. Standard: a mini-design in the PR body. **`--grill` needs a design at any
+tier**, trivial included and in context rather than on disk: there is nothing to grill otherwise.
 
-**4. Checkpoint (unconditional slot).** `--drill` → hand `<RUN_DIR>/design.md` to `/drill:me`
-**first** (no plugin: hand the file over to read), appending each objection to the ledger as it
-is raised, never at the end — a drill is long enough to compact
-(`R/autonomy.md`). Then ask any open `asked` items in ONE batched `AskUserQuestion`; a `--drill`
-run asks even on an empty ledger, or the design goes unanswered. The only mid-run question.
+**4. Checkpoint (unconditional slot).** `--grill` → `mattpocock-skills:grilling` over the design
+you just built (absent: hand it over in the question itself), ledgering each decision as its round
+closes, never at the end — a grill is long enough to compact (`R/autonomy.md`). It ends on the
+user's confirmation and **replaces** the batched question, so every open `asked` item goes into
+its first round; a second ask after it is the fourth moment coming back. No flag → those items in
+ONE batched `AskUserQuestion`. Either way, the only mid-run question.
 
 **5. Plan + implement.** Turn the design into a plan (`superpowers:writing-plans` for
 complex+); TDD: failing test → implement → passing. UI/layout work is verified with
 `<visual_cmd>` or a browser test, never eyeballing.
 
-**6. Gates.** Config commands are authoritative; each one the config left empty you work
-out **in the worktree**, the tree the gates run in, from its manifests and CI workflow — as a
-**literal** (`npm test`, `bash tests/run-tests.sh`), never a string assembled from repository
-filenames, because `run-gates.sh` evaluates it through `bash -c`. Ambiguous ⇒ Step 4 asks.
-`S/run-gates.sh --log-dir "<RUN_DIR>/logs" --gate typecheck='<typecheck_cmd>' --gate
-test='<test_cmd>'` (+ `--gate visual=…` for UI). A command carrying a quote of its own closes that
-wrapper: put it in a shell variable in the same call and pass `--gate "test=$t"`, so the value
-reaches the script as one argument. Never judge a gate from an ad-hoc command: only this one
-surfaces the real failure. An empty gate command degrades (exit 4), never a false green.
-Red ⇒ STOP and fix.
+**6. Gates.** Config commands are authoritative; each one the config left empty you work out **in
+the worktree**, the tree the gates run in, from its manifests and CI workflow — as a **literal**
+(`npm test`, `bash tests/run-tests.sh`), never a string assembled from repository filenames,
+because `run-gates.sh` evaluates it through `bash -c`. Ambiguous ⇒ Step 4 asks. `S/run-gates.sh
+--log-dir "<RUN_DIR>/logs" --gate typecheck='<typecheck_cmd>' --gate test='<test_cmd>'` (+
+`--gate visual=…` for UI). A command carrying a quote of its own closes that wrapper: put it in a
+shell variable in the same call and pass `--gate "test=$t"`, so the value reaches the script as
+one argument. Never judge a gate from an ad-hoc command: only this one surfaces the real failure.
+An empty gate command degrades (exit 4), never a false green. Red ⇒ STOP and fix.
 
 **7. Review loop.** Claude Code's built-in `code-review` skill at the tier's level, ≤ tier's max
 passes, and **without `--fix`** — that flag applies findings in one sweep, past the per-fix re-gate
@@ -117,43 +116,44 @@ from the diff whether it reaches auth, crypto, secrets, sessions, payments or mi
 `/security-review` if it does — judging the code, not the filename. A floor you may escalate from
 and never argue down: anything under `auth`, `crypto`, `secrets` or `migrations`, plus `.env*`,
 `*.sql`, `*.pem`, `*.key`.
-**Escalate a level** on 2+ confirmed bugs in a pass or a gate failing twice; re-run gates
-after each fix.
+**Escalate a level** on 2+ confirmed bugs in a pass or a gate failing twice; re-run gates after each fix.
 
-**8. Re-gates + simplification gate.** Re-run `run-gates.sh` (all green). For any gate command you
-worked out yourself, **print** (never write) the `<CONFIG_PATH>` frontmatter block in the report.
-Then the **simplification gate**, at most two passes: `/ponytail:ponytail-review` (when installed)
-for what to delete, built-in `simplify` for what stays but gets simpler, over `git diff <BASE>` (two dots, never
-three) plus any untracked file `<CHANGED>` names. Apply the cuts you
-agree with, re-run gates, stop as soon as a pass finds nothing; the rest gets one line each in
-the report. Lenses and fallbacks: `R/companions.md`.
+**8. Re-gates, simplification, verify.** Re-run `run-gates.sh` (all green). For any gate command
+you worked out yourself, **print** (never write) the `<CONFIG_PATH>` frontmatter block in the
+report. Then the **simplification gate**, at most two passes: `/ponytail:ponytail-review` (when
+installed) for what to delete, built-in `simplify` for what stays but gets simpler, over `git diff
+<BASE>` (two dots, never three) plus any untracked file `<CHANGED>` names. Apply the cuts you agree
+with, re-run gates, stop as soon as a pass finds nothing; the rest gets one line each in the
+report. Lenses and fallbacks: `R/companions.md`.
+Then built-in **`verify`**, `standard`+ and **last**: build the change and drive it at its own
+surface, past the happy path. A diff with nothing runnable in it skips the slot outright. A FAIL
+is stop-and-fix and re-gate, never a ratchet count. Why each of those three: `R/companions.md`.
 
 **9. Commit + PR + report.** `git add <explicit paths>`, conventional subjects; `git push -u
 origin <branch>`. **Re-run `run-gates.sh` on the commit** — the receipt names the HEAD it ran
-against, so the pre-commit run does not cover it. Then `gh pr create` against `BASE`,
-`Closes #<N>`, humanized body (autonomous-decisions section + rejected alternatives).
-Board-mode: move the card to *in review* the same way. Then report, length per tier (3 lines →
-full): what was built and why, test status with the green proof, the autonomous decisions, the PR
-link, and how much machinery ran (gate runs, review passes and level). Ask when to merge, and
-**stop** — merging is the next step.
+against, so the pre-commit run does not cover it. Then `gh pr create` against `BASE`, `Closes
+#<N>`, humanized body (autonomous-decisions section + rejected alternatives). Board-mode: move
+the card to *in review* the same way. Then report, length per tier (3 lines → full): what was
+built and why, test status with the green proof, the autonomous decisions, the PR link, and how
+much machinery ran (gate runs, review passes and level). Ask when to merge, and **stop** —
+merging is the next step.
 
 ## Step 10 — Merge on approval (GATE)
 
 Return to your working tree first: `cd` into the `WT_PATH` you recorded at Step 1 (worktree
 mode); in the in-place fallback stay in the main checkout on `<branch>`. Read the reply against
 *this* PR. A `review-blocked` / `review-unreadable` stop is a real answer, not a hiccup: route it
-through change-requests. **Merge only on an unambiguous
-go-ahead to merge THIS PR; if the reply (or GitHub review) is anything else, do not merge.**
+through change-requests. **Merge only on an unambiguous go-ahead to merge THIS PR; if the reply
+(or GitHub review) is anything else, do not merge.**
 - **Go-ahead** ("merge it", "lgtm, ship it", "approved", "go ahead and merge") → `S/worktree.sh
   merge <N> --branch <branch>`, the only sanctioned merge path (what it refuses, and why:
-  `R/contracts.md`). On a
-  `STOP_REASON` rung follow `R/merge-ladder.md`; on exit 2, **skip cleanup**.
+  `R/contracts.md`). On a `STOP_REASON` rung follow `R/merge-ladder.md`; on exit 2, **skip
+  cleanup**.
 - **Change requests** → implement in the worktree, **re-run the tier gates** (Steps 6–7 on the
   new diff) until clean, push, re-report, wait again. Never merge unverified changes.
 - **Anything else** → do **not** merge. A vague ack ("ok", "looks fine") or a question → ask for
-  explicit confirmation. If they'll self-merge/abandon, offer `S/worktree.sh cleanup <N>
-  --branch <branch> --keep-branch` (removes the tree, keeps the PR + branch). Approval is
-  never inferred.
+  explicit confirmation. If they'll self-merge/abandon, offer `S/worktree.sh cleanup <N> --branch
+  <branch> --keep-branch` (removes the tree, keeps the PR + branch). Approval is never inferred.
 
 ## Step 11 — Cleanup (after a successful merge)
 
@@ -167,9 +167,8 @@ refreshed base and open a **draft** PR from it. Never auto-revert, never merge i
 Then `S/worktree.sh cleanup <N> --branch <branch>` (removes the worktree, deletes the merged
 local + remote branch, prunes the receipt and run dir). It refuses a branch that is the base of
 an open PR. Report from its keys — `DELETED_LOCAL=false` or a `LEFTOVER_DIR` means a locked dir
-remains; say so, remove it by hand once the lock clears. In-place fallback (no worktree):
-switch off `<branch>`, delete it local+remote, sweep the scratchpad temp (keep committed
-`docs/`, PR content, anything you were asked to keep). Details: `R/contracts.md` →
+remains; say so, remove it by hand once the lock clears. In-place fallback (no worktree): switch
+off `<branch>`, delete it local+remote, sweep the run's temp. Details: `R/contracts.md` →
 "worktree.sh". Finish with one line: what merged, what was removed, what was kept.
 
 ## Friction log

--- a/plugins/issue-to-pr/skills/run/references/autonomy.md
+++ b/plugins/issue-to-pr/skills/run/references/autonomy.md
@@ -3,12 +3,29 @@
 The pipeline decides what it reasonably can on its own, records every decision, and
 surfaces the automatic ones where the human already looks: the report and the PR body.
 
-## Ask contract — three moments, plus one the user asks for
+## Ask contract — three moments
 
-Contact the user at these three points, and at a fourth only if asked (below):
+Contact the user at these three points. Nothing in the run may interrupt them anywhere else; a
+flag they passed themselves can.
 
 1. **Step 4 checkpoint** — ONE batched `AskUserQuestion`, only if the ledger has open
-   `asked` items. This is the single mid-run question.
+   `asked` items. This is the single mid-run question, and it may move **earlier**, to Step 0,
+   when the ambiguity is in the request rather than in the design: the same one question, spent
+   sooner.
+
+   `--grill` spends the slot differently rather than adding to it: `mattpocock-skills:grilling`
+   works the design tree in rounds, each a numbered set of decisions with a recommended answer,
+   until the frontier is empty and the user confirms. It **replaces** the batched question, so
+   every open `asked` item goes **into** the grill, in its first round: the grill works the
+   design tree, the ledger holds what is not on it — a new dependency, a gate command Step 6
+   could not settle — and an item the grill never reaches is an item nobody asks. Ledger each
+   decision **as its round closes**, never in a batch at the end: a grill runs long enough for
+   the context to compact, and a decision that lived only in its transcript is gone when it
+   does. Anything surfacing after it belongs to moment (3), like any other late arrival.
+
+   Under the flag the grill **always** runs, including on a run whose scope question already
+   went at Step 0: Step 0 cannot defer that one, since an issue it drafts on a guessed scope is
+   the wrong issue. The flag is the user electing the longer form, and nothing here cancels it.
 2. **The merge gate** (Step 10) — always.
 3. **A hard stop** — anything with no safe default: an exit-2 (`WARN_CLAIMED_BY`, a
    gate-critical unknown), or a preference-bound choice that surfaced too late for
@@ -23,12 +40,6 @@ A question is for the user (`kind: asked`) only when it is:
 Everything else is decided autonomously (`kind: auto`) and logged. Forbidden: proceeding
 past the checkpoint with a gate-critical unknown; asking mid-implementation anything that
 fits moment (1).
-
-## The fourth moment: `--drill`
-
-Append each objection to the ledger **as it is raised**, never in a batch at the end: a
-tutoring session is long enough for the context to compact, and a decision that lived only
-in the drill's transcript is gone when it does.
 
 ## Ledger
 
@@ -53,9 +64,9 @@ the claim, the `decision` is what you built on it, and the `rationale` carries w
 **and where** — a conclusion with no source reads exactly like the guess this rule exists to
 stop.
 
-It goes here and **never into a design file**. `<RUN_DIR>/design.md` exists only on `complex` or
-under `--drill`, and Step 11 prunes it once the change lands on the default branch, so a citation
-left there is deleted before any reader sees it. The ledger is the one path that reaches the PR
+It goes here and **never into a design file**. `<RUN_DIR>/design.md` exists only on `complex`, and
+Step 11 prunes it once the change lands on the default branch, so a citation left there is
+deleted before any reader sees it. The ledger is the one path that reaches the PR
 body from every tier.
 
 Use whatever search the session offers, except `/deep-research` (`R/companions.md`). Nothing else

--- a/plugins/issue-to-pr/skills/run/references/board.md
+++ b/plugins/issue-to-pr/skills/run/references/board.md
@@ -1,8 +1,8 @@
 # Board sync — GitHub Projects v2
 
 Read only when the config names `board.url` (`R/configuration.md`). Everything here is
-**best-effort at every step**: any failure is one reported line and the run continues. A
-board hiccup never blocks the pipeline, and nothing here is worth debugging mid-run.
+**best-effort**: any failure is one reported line and the run continues. Never debug a board
+hiccup mid-run.
 
 `gh auth status` must list the `project` scope. Without it, say once that board sync is off
 and carry on with plain issues; the fix is `gh auth refresh -s project`. A fine-grained token
@@ -27,9 +27,8 @@ opts=$(gh api graphql -f query='query($proj:ID!,$field:String!){node(id:$proj){.
 printf 'ITEM=%s\nOPTS=%s\n' "$item" "$opts"
 ```
 
-A failed call leaves on its own rung, which is what lets the next paragraph read an empty
-`opts` as an answer. Twenty items is the whole search: an issue carried on more boards than
-that reads as not on this one, and that is the trade, not an oversight.
+Each `||` rung is why an empty `opts` below is an answer rather than a failure. Twenty items is
+the whole search: an issue whose target board falls outside that first page reads as not on it.
 
 `opts` empty means the board has no `Status` field at all, which is not the same as a Status
 field with no matching column — say which one it was. Otherwise pick the option: `status_map`
@@ -40,7 +39,8 @@ ready for review. Then set it:
 
 ```bash
 gh api graphql -f query='mutation($proj:ID!,$item:ID!,$field:ID!,$opt:String!){updateProjectV2ItemFieldValue(input:{projectId:$proj,itemId:$item,fieldId:$field,value:{singleSelectOptionId:$opt}}){projectV2Item{id}}}' \
-  -F proj=<PROJECT_ID> -F item=<ITEM_ID> -F field=<FIELD_ID> -F opt=<OPTION_ID>
+  -F proj=<PROJECT_ID> -F item=<ITEM_ID> -F field=<FIELD_ID> -F opt=<OPTION_ID> \
+  || { echo "BOARD=set-failed"; exit 0; }
 ```
 
 `Done` is never set here: GitHub's own automation moves the card when the PR merges into the

--- a/plugins/issue-to-pr/skills/run/references/companions.md
+++ b/plugins/issue-to-pr/skills/run/references/companions.md
@@ -10,14 +10,17 @@ companion silently degrade quality without saying so.
 | Design critique (Step 3, complex) | `/cross-review` over the produced design | Adversarially self-critique the design against the code, then revise. |
 | Humanizing human-facing text (Step 9) | `humanizer` | Self-edit the PR body / report to drop AI-tell phrasing; flag that a humanizer pass would help. |
 | Lazy design and build (Steps 3–5) | `ponytail:ponytail full`, set once before the design | Design and build against the same ladder by hand: does this need to exist, does the stdlib or the platform already do it, can it be one line. |
-| Human drill on the design (Step 4, `--drill` only) | `drill:me` over `<RUN_DIR>/design.md` | Hand the file to the user to read and ask them directly. |
+| Grilling the design (Step 4, `--grill` only) | `mattpocock-skills:grilling` over the design you just built | Hand the design over in the batched question itself, with your open `asked` items, and take their objections as the round. Still one contact, not two. |
 | Deletion lens (Step 8) | `ponytail:ponytail-review` over the run's diff | Re-read the diff hunting only for what to delete: reinvented stdlib, one-caller abstractions, config nobody sets, flags nobody passes. |
 | Simplification lens (Step 8) | `simplify` | Re-read the diff for what survives but reads worse than it has to: a branch that only ever takes one path, a loop the stdlib has a name for, a comment explaining a name that should have been the name. |
 | Diff review loop (Step 7) | `code-review` at the tier's level | Independent adversarial review subagents (2–3) critique the diff for correctness, reuse, and regressions; iterate. |
 
-`code-review` and `simplify` are **built into Claude Code** — invoke them by bare name, no
-install, no namespace, no `if installed` branch. They carry their own fallbacks when the
-Agent tool is unavailable, and `code-review` sizes its own finder fan-out to the diff.
+`code-review`, `simplify` and `verify` are **built into Claude Code** — invoke them by bare
+name, no install, no namespace, no `if installed` branch. They carry their own fallbacks when
+the Agent tool is unavailable, and `code-review` sizes its own finder fan-out to the diff.
+`verify` has no row above because it has no fallback worth the name: driving a built artifact
+at its real surface is not something you approximate by reading the diff again. Which tiers get
+the slot is `R/tier-matrix.md`; the rules that govern it are at the bottom of this file.
 
 `deep-research` is built in as well, but it is **not the run's to use**: since 2.1.218 Claude
 Code starts it only when the user types `/deep-research` themselves. There is no branch here
@@ -31,6 +34,24 @@ a time, re-running the gates between them.
 Ponytail's own `SubagentStart` hook carries the mode into every subagent, so setting it once
 at Step 3 is the whole wiring — pass nothing along. Step 7's reviewers inherit it too; their
 prompt says it governs how a confirmed bug gets fixed, never whether it counts as one.
+
+## The Step 8 verify slot
+
+Green gates prove the tests pass. They do not prove the thing the PR claims to do actually
+happens. That gap is what the slot closes, and it is why the three rules are what they are.
+
+**Last in the step, after simplification.** That gate is still applying cuts and re-gating, so
+anything verified ahead of it was verified against a diff that then moved.
+
+**A diff with nothing runnable skips the slot, rather than recording a skip.** Research, docs and
+prose outcomes have no surface to drive, and a verdict collected on every run, most of them
+empty, is one nobody reads by the tenth PR. This pipeline's own runs skip more often than not:
+its surface is a Claude session reading prose, which no terminal can drive.
+
+**A FAIL never counts toward the ratchet.** The ratchet raises the review level, a level only
+buys another review pass, and by Step 8 the loop has closed: the escalation would have nothing
+to spend. A FAIL is stop-and-fix and re-gate, and the fix lands after the last review pass,
+where "Work no reviewer saw" in `R/autonomy.md` already covers it.
 
 These are recommendations, not requirements — the skill checks availability at the relevant
 step and proceeds either way.

--- a/plugins/issue-to-pr/skills/run/references/configuration.md
+++ b/plugins/issue-to-pr/skills/run/references/configuration.md
@@ -10,7 +10,8 @@ directory holds the plugin's repository-level state and carries its own `.gitign
 **first** rule is `*`, so a teammate without the plugin never sees a file they cannot place
 and the project's own `.gitignore` is never edited. Create it that way before writing
 anything into it — the friction log and the gate receipt both land there. A run's own files
-live beside it under `runs/task-<N>/` and go at cleanup. A config left at the pre-2.5 path
+live beside it under `runs/task-<N>/` and go at cleanup: that path, in the main checkout and
+never in a worktree, is the `<RUN_DIR>` the spine writes designs and gate logs to. A config left at the pre-2.5 path
 (`.claude/issue-to-pr.local.md`) is not read: say so once and leave the file alone.
 
 ```yaml

--- a/plugins/issue-to-pr/skills/run/references/contracts.md
+++ b/plugins/issue-to-pr/skills/run/references/contracts.md
@@ -65,6 +65,10 @@ directory (same protection as `ensure`): it reports the path as `LEFTOVER_DIR` a
 the remote branch. Check `DELETED_LOCAL` — if a still-registered locked worktree remains
 it stays `false`; delete that branch and the leftover yourself once whatever holds it is gone.
 
+In the in-place fallback (exit 3) there is no worktree to remove, so Step 11 sweeps the run's
+temp by hand instead: keep anything committed under `docs/`, the PR's own content, and whatever
+the user asked you to keep.
+
 `--keep-branch` — user self-merges / abandons. Removes the worktree only, skips both
 preconditions and **never touches the branch or PR**. Keys: `REMOVED KEPT` (`branch-and-pr`),
 plus `LEFTOVER_DIR`.

--- a/plugins/issue-to-pr/skills/run/references/tier-matrix.md
+++ b/plugins/issue-to-pr/skills/run/references/tier-matrix.md
@@ -9,6 +9,7 @@ moved it. Borderline picks the **higher** tier.
 |---|---|---|---|
 | Design | - | mini-design in the PR body | design panel, then `/cross-review` |
 | `code-review` level | `low`, 1 pass | `medium`, <=2 passes | `high`, <=3 passes (may raise to `max` on escalation) |
+| Step 8 `verify` | - | when the diff left something runnable | as standard |
 
 Gates, the security overlay, and the external-claim check run at every tier, always. That last
 one scales to nothing at all, so it lives in `R/autonomy.md` with the other ledger rules rather
@@ -29,9 +30,9 @@ tiers on the wider scope.
 Count CONFIRMED `code-review` verdicts per pass, and consecutive failures per gate. When
 **2+ confirmed bugs land in one review pass**, or **the same gate fails twice**, escalate the
 review level one notch (never down). A `trivial` run becomes `standard`, which raises the cap
-along with the tier and gives it a design step to re-enter; raising a level inside a tier buys
-no extra pass. Report the raw per-pass counts at Step 9 so a missed ratchet is visible at the
-merge gate.
+along with the tier and gives it both a design step and the Step 8 verify slot to re-enter;
+raising a level inside a tier buys no extra pass. Report the raw per-pass counts at Step 9 so a
+missed ratchet is visible at the merge gate.
 
 The cap is the cap. Another pass is how a review loop stops terminating, and the human at the
 merge gate is the backstop this pipeline is built on. So stop, and ledger what stopping cost —

--- a/plugins/issue-to-pr/skills/setup/SKILL.md
+++ b/plugins/issue-to-pr/skills/setup/SKILL.md
@@ -35,9 +35,9 @@ Report the account and the scopes you actually saw, not a summary of them.
 
 ## 2. What ships in Claude Code already
 
-`code-review` (Step 7) and `simplify` (Step 8) are registered by the CLI itself. There is
-nothing to install and no marketplace involved, and an official plugin also called
-`code-review` is a different thing. Say they are present, so nobody goes looking.
+`code-review` (Step 7), `simplify` and `verify` (both Step 8) are registered by the CLI
+itself. There is nothing to install and no marketplace involved, and an official plugin also
+called `code-review` is a different thing. Say they are present, so nobody goes looking.
 
 `/deep-research` needs no install either, for a different reason: Claude Code only starts it
 when the user types it, never on Claude's own initiative. Nothing to check, then, and nothing
@@ -57,7 +57,7 @@ without them.
 | `ponytail` | `/plugin marketplace add DietrichGebert/ponytail` then `/plugin install ponytail@ponytail` |
 | `superpowers` | `/plugin marketplace add anthropics/claude-plugins-official` then `/plugin install superpowers@claude-plugins-official` |
 | `humanizer` | `/plugin install humanizer@dmitriy-claude-plugins` |
-| `drill` | `/plugin marketplace add timini/drill-me` then `/plugin install drill@drill-me` |
+| `mattpocock-skills` (`grilling`) | `/plugin marketplace add anthropics/claude-plugins-official` then `/plugin install mattpocock-skills@claude-plugins-official` |
 | `codex-collaboration` (`/cross-review`) | Codex first: `/plugin marketplace add openai/codex-plugin-cc`, `/plugin install codex@openai-codex`, `/codex:setup`. Then `/plugin install codex-collaboration@dmitriy-claude-plugins` |
 
 ## 4. The optional config

--- a/plugins/issue-to-pr/tests/contract/test_skill-lint.sh
+++ b/plugins/issue-to-pr/tests/contract/test_skill-lint.sh
@@ -86,22 +86,47 @@ test_skill_smoke_gate_passes_a_log_dir_before_cleanup() {
   assert_contains "$c" 'run-gates.sh --log-dir "<RUN_DIR>/logs"'
 }
 
-# `--drill` is the one way a run spends the human's time on purpose instead of saving it: it
-# hands the design to /drill:me at the checkpoint. Ordering is the contract, not decoration —
-# the drill runs BEFORE the batched question so an objection it surfaces still fits in that
-# same slot rather than needing a second one. A flag nobody can discover is a flag nobody
-# passes, so the frontmatter has to advertise it too.
-test_skill_drill_is_opt_in_and_precedes_the_batched_question() {
-  local blk d a
-  grep -q 'argument-hint:.*--drill' "$(skill_md)" ||
-    fail "argument-hint must advertise --drill"
+# `--grill` is the one way a run spends the human's time on purpose instead of saving it. It
+# REPLACES the batched question rather than joining it: grilling works the design tree in
+# rounds until the frontier is empty and stops on the user's confirmation, which is the
+# checkpoint's own job done properly. So the number in the ask contract stays three.
+#
+# Its predecessor `--drill` did add a fourth moment, and that is the shape an edit restores by
+# reflex, so the old flag and the old count are both checked for below. A flag nobody can
+# discover is a flag nobody passes: the frontmatter advertises it.
+test_skill_grill_reshapes_the_checkpoint_without_adding_a_moment() {
+  local s blk ask f live
+  s=$(cat "$(skill_md)")
+  [ -n "$s" ] || fail "SKILL.md came back empty; this check would be vacuous"
+  grep -q 'argument-hint:.*--grill' "$(skill_md)" ||
+    fail "argument-hint must advertise --grill"
+
+  # Every file that carried a drill row, not just the spine - that is where the rot would sit,
+  # and the companion walk below asks for `grilling` without forbidding what it replaced.
+  # CHANGELOG.md is deliberately exempt: it is version-scoped and its history is meant to age.
+  for f in "$(skill_md)" "$(setup_md)" "$ITP_SCRIPTS"/../skills/run/references/*.md \
+           "$ITP_SCRIPTS/../README.md" "$ITP_SCRIPTS/../../../README.md"; do
+    live=$(cat "$f")
+    [ -n "$live" ] || fail "$f came back empty; this check would be vacuous"
+    assert_not_contains "$live" 'drill' "$f still mentions drill, which the plugin no longer has"
+  done
+
   blk=$(skill_step 4)
-  d=$(printf '%s\n' "$blk" | grep -n '/drill:me' | head -1 | cut -d: -f1)
-  a=$(printf '%s\n' "$blk" | grep -n 'AskUserQuestion' | head -1 | cut -d: -f1)
-  [ -n "$d" ] || fail "the checkpoint must run /drill:me when the flag asked for it"
-  [ -n "$a" ] || fail "the checkpoint lost its batched AskUserQuestion"
-  [ "$d" -le "$a" ] ||
-    fail "the drill must come before the batched question, not after it"
+  [ -n "$blk" ] || fail "Step 4 came back empty; this check would be vacuous"
+  assert_contains "$blk" 'grilling' "the checkpoint must run the grill when --grill asked for it"
+  assert_contains "$blk" 'AskUserQuestion' "the checkpoint lost its batched question"
+  # That pair is not enough on its own: a Step 4 that grills and THEN fires the question
+  # satisfies both while spending two contacts, which is the fourth moment under a new name.
+  assert_contains "$blk" 'replaces' \
+    "Step 4 must say the grill REPLACES the batched question, not merely that both exist"
+
+  # -A3, not a bare grep: the bullet wraps over three lines, and a budget that keeps forcing
+  # reflows would move `four` off the matched line without the rule changing at all.
+  ask=$(printf '%s\n' "$s" | grep -A3 -i 'ask contract:')
+  [ -n "$ask" ] || fail "the spine no longer states the ask contract"
+  case "$ask" in
+    *four*) fail "the ask contract promises a fourth moment again: $ask" ;;
+  esac
 }
 
 setup_md() { printf '%s' "$ITP_SCRIPTS/../skills/setup/SKILL.md"; }
@@ -116,7 +141,7 @@ test_setup_walks_every_companion_the_run_knows() {
   comps=$(cat "$ITP_SCRIPTS/../skills/run/references/companions.md")
   [ ${#s} -gt 500 ] || fail "the setup skill is too short to be walking anyone through anything"
   [ ${#comps} -gt 500 ] || fail "companions.md came back short; the comparison would be vacuous"
-  for c in superpowers ponytail humanizer drill deep-research cross-review code-review simplify; do
+  for c in superpowers ponytail humanizer grilling deep-research cross-review code-review simplify verify; do
     assert_contains "$comps" "$c" "companions.md must still know the $c companion"
     assert_contains "$s" "$c" "setup must account for the $c companion the run relies on"
   done
@@ -139,12 +164,13 @@ test_setup_walks_every_companion_the_run_knows() {
 # included. Deliberate. A false red costs a minute; a false green shipped this bug twice.
 # Reword the prose or narrow the slice, never delete the check.
 #
-# `verify` is not guarded yet: absent from the plugin, so the entry would be speculative and
-# the substring would go red on prose that merely says "verify". Add it with the Step 8 slot.
+# `verify` joined the set with the Step 8 slot. It is the riskiest name of the four, because
+# unlike the others it is an ordinary English word: keep it out of these three regions by
+# rewording them, never by dropping it from the list.
 no_builtins() { # region label
   local c
   [ -n "$1" ] || fail "$2 came back empty; this check would be vacuous"
-  for c in code-review simplify deep-research; do
+  for c in code-review simplify deep-research verify; do
     assert_not_contains "$1" "$c" "$2 offers $c, which Claude Code already registers"
   done
 }


### PR DESCRIPTION
Two issues about the same weak spot: the pipeline's last stretch, and its one opt-in flag. Green gates never proved the change works, and `--drill` taught a design the human was supposed to shape.

Closes #58
Closes #56

## #58: a verify slot at the end of Step 8

Tests passing and "the thing in the PR title happens" are different claims, and only one of them had a gate. Built-in `verify` builds the change and drives it at its own surface, past the happy path. It runs on `standard` and up, last in Step 8.

**Last, not first.** The issue asked for it after the green gate; Step 8 holds two things and the second one still moves the diff. The simplification gate applies cuts and re-gates, so anything verified ahead of it is verified against an artifact that then changes. Going last means what got driven is what Step 9 commits.

**A diff with nothing runnable skips the slot rather than recording a skip.** A verdict collected on every run, most of them empty, is one nobody reads by the tenth PR. Worth admitting: this plugin's own runs will skip more often than not, because its surface is a Claude session reading prose and no terminal can drive that.

**A FAIL never counts toward the escalation ratchet.** This was the issue's open question, and it answers itself from last release. The ratchet raises the review *level*; a level only buys another review pass; by Step 8 the review loop has closed. Firing it there is an escalation with nothing to spend, which is the exact promise v5.3.0 deleted from `tier-matrix.md`. So a FAIL is stop-and-fix and re-gate, and the fix then lands after the last review pass, where `autonomy.md`'s existing "work no reviewer saw" entry already covers it. #63's fix absorbed #58's open question and nothing new was written.

## #56: `--drill` becomes `--grill`, and the contract goes back to three moments

`drill:me` is a tutor. It takes the finished design and walks you through it, so knowledge flows from the agent to you, which is why the flag had to add a **fourth** contact moment: teaching is contact on top of the question, not instead of it.

`mattpocock-skills:grilling` runs the other way. It maps the design as a tree and works the frontier in rounds, each round a numbered set of decisions with a recommended answer attached to every one. It finds facts itself and puts only the decisions to you. It ends when the frontier is empty and you confirm.

That is the batched question's own job, done properly. So `--grill` **replaces** the checkpoint rather than adding to it, and the ask contract loses its exception clause: three moments, always. Both of the issue's open questions land on the same answer, and the result is a smaller contract than the one it replaces:

- The contract is neither suspended nor given a new clause. One bounded stretch occupies the slot the batched question would have used.
- The grill replaces the batched question rather than feeding it. It cannot leave the batch empty because there is no batch left to be empty, and anything surfacing afterwards routes to moment (3), which v5.3.0 widened for exactly that case.

Falling out of it: Step 3 loses its `--drill` clause outright, since grilling takes no file and reads the tree from context. `autonomy.md` loses a whole section. And `setup` drops `timini/drill-me`, the only third-party marketplace the plugin asked anyone to add; `mattpocock-skills` ships from `claude-plugins-official`, already added for `superpowers`.

## What I checked instead of assuming

The issue says `verify` reports PASS/FAIL/BLOCKED/SKIP and writes a recipe back to `.claude/skills/verifier-*`. I could confirm neither. The CLI is a compiled binary now, and while its bundled skill list is readable (`["verify","pr","commit","code-review","simplify","go"]` at 2.1.251, so the name is real), skill bodies are not. So the prose leans on neither claim. Documenting an unverified contract is precisely how the `deep-research` mistake happened two releases ago, and that one took four files to undo.

## Tests

The tests were written first, and red for the right reasons, before any prose changed. The drill-ordering test is gone, since nothing follows the grill to be ordered against; what replaces it guards the thing that can actually regress, which is the *count* in the contract. Both `--drill` and the word "four" are checked for by name.

`verify` also joined the built-ins guard. That guard exists because a built-in has twice been advertised as something to install, and `verify` is the riskiest of the four names in it: unlike the others it is an ordinary English word, so the comment now says to keep it out of those three regions by rewording them, never by dropping it from the list.

Nineteen mutation attempts across two rounds. Three came back green: one that landed but did not remove the fact under test, and two that never landed at all because my `sed` pattern did not match. A mutation that fails to apply looks identical to a live guard passing, which is the same trap as a vacuous assertion one level up. Corrected versions killed all three.

## What the review found

Twelve findings, eleven fixed. The two that mattered most were both the release recreating a defect it had just removed.

**The `Otherwise` closed a door on the ask contract.** Step 4 read "the grill replaces the batched question. *Otherwise* ask any open `asked` items". Those are mutually exclusive, so on a `--grill` run an open ledger item never reached anyone. The grill works the *design tree*; the ledger holds things that are not on it, like a new dependency or the gate command Step 6 could not settle and explicitly delegates to Step 4. `--drill` had no such hole precisely because it *fed* the question rather than replacing it. Open items now go into the grill's first round, and both the spine and `autonomy.md` say a second ask after it is the fourth moment under a new name.

**`--grill` had nothing to grill below `complex`.** Deleting the old `--drill` clause took with it the guarantee that a design exists at any tier. `--tier trivial --grill` had no design at all, and `standard`'s design is a mini-design *in the PR body*, which does not exist until Step 9. The flag now requires a design at any tier, in context rather than on disk.

Also fixed: the fallback row still told a run to hand the design over *and then* fire the batched question, which is the same two-contact bug in the reference file. The `<RUN_DIR>` keep-list I moved into `contracts.md` landed under the wrong heading, two sections from where the pointer sends you. Step 0 lost the qualifier that made its early question legal in the same change that hardened `autonomy.md` to "nowhere else". `companions.md` told the report to announce a skipped `verify` while `tier-matrix.md` made a point of the skip being unrecorded. And the changelog claimed `drill-me` was the only third-party marketplace in the setup table, which is false. `ponytail` and `codex-plugin-cc` are both still there, and that line goes into the GitHub release.

Three of the twelve were about the tests, and they are the ones worth reading:

- The new guard could not catch its own comment's bug. It asserted Step 4 mentions the grill and mentions `AskUserQuestion`, which a Step 4 that grills *and then* asks satisfies perfectly. It now asserts the word `replaces`.
- The fourth-moment guard was line-scoped. The contract bullet wraps over three lines, and the 180-line budget keeps forcing reflows, so moving the wrap point would have hidden the word without changing the rule. Now `-A3`.
- The `--drill` guard read only the spine, while every file that actually carried a drill row (both READMEs, `companions.md`, `autonomy.md`, `setup`) had none. It now walks all of them.

**One finding accepted rather than fixed:** `verify` sits in the companion-walk loop as a bare substring, so if the Step 8 slot were removed later while any lowercase "verify" sentence survived, that assertion would stay green. Guarding it properly means machinery I do not think the risk is worth. It is the weakest assertion in the file and this line is the record of that.

## The budget, and the debt

`SKILL.md` ends at **170**, nine lines below where it started, with both features in it. The **mandatory Step 0-1 read goes 382 to 361**: v5.3.0 spent a whole audit getting that number to 382, and this release takes another 21 off it while adding a step and rewiring a flag.

| read every run | before | after |
|---|---|---|
| `SKILL.md` | 179 | 170 |
| `configuration.md` | 86 | 84 |
| `autonomy.md` | 78 | 69 |
| `tier-matrix.md` | 39 | 38 |
| **total** | **382** | **361** |

`README.md` drops 111 to 106, `companions.md` and `board.md` a line each, and the whole diff **deletes more lines than it adds**.

Getting there took a deletion pass over prose that was not part of either issue, because the plugin had been accumulating justification faster than rules. Signpost sentences announcing what the next paragraph would say. A reference narrating its own version history. `companions.md` restating the `--fix` rule the spine already gives with its reason, then closing on a line that repeated its own opening.

**The friction log is gone entirely.** `tune` was removed in v4 and was the only thing that ever read `.claude/issue-to-pr/friction.log`, so every run since has appended to a file with no consumer. That is a whole concept out of the spine, and it is outside what #58 and #56 asked for: say the word and it comes back.

After cutting that hard I diffed every skill file against `main` at word level and listed every phrase of six or more words that had disappeared. Almost all of it was justification. **One was a rule**: the shape of the unreviewed-work ledger entry had vanished from `autonomy.md` and from the `tier-matrix.md` line pointing at it, both at once. Restored.

## The simplification gate

Two lenses, two passes, then it terminated on a pass that found nothing.

The deletion lens took roughly ten lines out of the two reference files, mostly signpost sentences announcing what the next paragraph was about to say and one clause where a reference narrated its own version history.

The clarity lens found the one that matters: **the ask contract was stated twice in `SKILL.md`, and this diff reworded both copies without collapsing them.** That is the drift mechanism the branch merged this morning was named after. One release after fixing it, I edited both halves of a live instance and did not see it. Collapsing it also bought the line the budget needed.

I rejected one of its fixes. It proposed that under `--grill`, Step 0's scope question should wait for the grill's first round, which would make "three moments" literally true. But Step 0 cannot defer that question: it drafts an issue that "restates the request and nothing more", and if the scope is ambiguous there is no faithful restatement to write. The fix would trade an asterisk on a number for a wrong issue. The diagnosis underneath was right, so I removed the defensive framing instead and stated the behaviour a run actually needs: under the flag the grill always runs.

The altitude lens found nothing to change, and answered the question I put to it directly: the new file-walk should **not** share a helper with the two loops already in that file. They are transposed (fixed needle over varying files, varying needle over fixed files, an allowlist over a sliced region), and two of the three assert in opposite directions. Merging them buys a mode flag and a swapped loop in exchange for three six-line blocks with hand-written failure messages.

## The verify slot, on the run that adds it

It skipped, which is what `tier-matrix` predicts for this repo: the surface of a change to pipeline prose is a Claude session reading it, and no terminal drives that.

Worth saying plainly, since skipping the feature you just built is a suspicious result. What actually goes unverified here is whether `--grill` works end to end, and the load-bearing part of that is one external claim: that `mattpocock-skills:grilling` exists and answers to that name. It was checked against the installed skill at 1.2.3, and the review confirmed it independently in `claude-plugins-official` at the SHA the marketplace pins. Running the flag for real would mean starting an interview with you that nobody asked for.

## Decisions made autonomously

- **A verify FAIL does not feed the ratchet.** An escalation after the review loop closes has no pass to spend, which is the defect v5.3.0 removed.
- **`--grill` reshapes moment (1) instead of adding a fourth.** Grilling ends on your confirmation, which is what the checkpoint is for. Counting it separately would make the contract's own number meaningless whenever the flag is on.
- **The grill replaces the batched question, and open ledger items go into it.** Review caught the first half shipping without the second: the grill works the design tree, and a dependency or an unsettled gate command is not on that tree, so "replaces" alone would have left those items unasked.
- **Under `--grill`, Step 0 hands its scope question to the grill.** I rejected this once and was wrong; see below.
- **The Step 8 verify slot skipped on this run.** Pipeline prose has no surface a terminal can drive, which is the case `tier-matrix` says will be the common one here.
- **The verify slot goes last in Step 8**, after simplification, because that gate still changes the diff.
- **`verify` is a real, model-startable built-in.** Checked against the CLI binary at 2.1.251. Unlike `deep-research`, nothing gates it to manual invocation only.
- **The verdict vocabulary and the recipe path stay out of the prose**, because they could not be verified.
- **Designed inline rather than with the complex tier's Workflow panel.** This session's operating instructions forbid starting a Workflow unprompted; Step 3 already names inline design as the sanctioned fallback.
- **The friction log is deleted, not just left unwritten.** Nothing has read it since `tune` went away. This is beyond the two issues.
- **The plugin description is unchanged.** It lists the gates that hold *every* run, and `verify` skips on `trivial` and on unrunnable diffs, so adding it would have made a true sentence false.
- **Tier `complex`.** Two issues, several existing paths, and a removed flag; the matrix says a borderline call takes the higher tier.

## At the gate

One `code-review` pass at the complex tier's `high` level, which found twelve. Then the two-lens simplification gate, which found four more across two passes and stopped on the third.

The cap was not reached and the ratchet never fired, so nothing here arrives unread. Every fix in this branch was made before the last pass that looked at it, and the passes after it came back clean.

## The review round on this PR, and one rejection I got wrong

Five findings, all acted on.

**A rule I added collided with one already there.** `verify` made Step 8 a place with gates in it, and Step 7 says the review level escalates when "a gate fails twice", so repeated verification failures would have driven the ratchet in the same release that says a verify FAIL never touches it. Two rules, each correct alone, contradicting from the moment the word appeared in a step heading. The trigger now names Step 6 gates.

**The `--grill` and Step 0 overlap: I rejected this once and was wrong.** Both reviewers reached it independently, which is what made me look again. My argument was that Step 0 cannot defer its scope question, because an issue drafted on an ambiguous request is the wrong issue. That does not hold: Step 0 drafts an issue that "restates the request and nothing more", and restating an ambiguity is a faithful issue. Nothing is built before the grill settles it in round one. So under the flag Step 0 keeps the question for the grill, the two paths are mutually exclusive, and "three moments" is literally true instead of carrying an apologetic paragraph.

**One I fixed the other way round.** The reviewer asked what Step 8 does when `verify` is unavailable. There is no unavailable case: it is a built-in, and adding a fallback would give the run a branch it can never take. The real defect was the sentence next to it, claiming all three built-ins "carry their own fallbacks when the Agent tool is unavailable". I never checked that for `verify` and I cannot: the CLI is a compiled binary whose skill bodies are unreadable. The claim is deleted rather than guessed at.

Plus: the changelog entries are imperative now, and the README heading that promised "one question max" says "one checkpoint max", since `--grill` deliberately asks in rounds.

## A second review round, after the deletion pass

Two more on `board.md`, both real.

**The Status mutation had no failure rung**, while the two discovery calls above it had gained one in the previous round. I added those because they feed a decision the model has to make; the mutation ends the chain, so it did not look like it needed one. But this file promises that any board failure is one reported line and the run continues, and a command with no handler cannot keep that promise. Three calls, two guarded: the inconsistency was the tell.

**The 20-item note was wrong rather than loose.** It said an issue on more than twenty boards reads as not on this one, which only holds if the target board is always last. What decides it is whether the target falls inside the first page, and that is what it says now.

## The friction log, finished

Removing the log from the spine left one live reference behind: a comment in `scripts/lib/common.sh` still listed it among the things the state directory holds. That is in this PR rather than a follow-up, because the changelog here already says the friction log is gone, and merging with the tree still naming it would ship exactly the kind of document that lies about the code which this plugin exists to prevent.

What stays is the changelog history: three entries in older releases that mention the log, and the 6.0.0 entry that removes it. Those are the record that the feature existed and was taken out. Editing them would make shipped release notes false.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the `--grill` workflow, replacing `--drill`, with interactive design interviews and round-by-round decisions.
  - Added a final verification gate for standard and complex runs when runnable changes are present.
  - Added support for the `mattpocock-skills:grilling` companion skill.

- **Bug Fixes**
  - Improved handling of board-update failures so runs continue while reporting the issue clearly.

- **Documentation**
  - Updated plugin guidance, configuration details, companion skill references, and release documentation for version 6.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->