### PR TITLE
refactor(issue-to-pr): deliver the prose cuts v6.0.0 left behind (v6.1.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -130,7 +130,7 @@
     {
       "name": "issue-to-pr",
       "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges; cleanup and the issue's auto-close follow only when the change landed in the default branch, and on any other base the run keeps the branch and says why. The board card advances as work moves.",
-      "version": "6.0.0",
+      "version": "6.1.0",
       "author": {
         "name": "Dmitry Yuhanov"
       },

--- a/plugins/issue-to-pr/.claude-plugin/plugin.json
+++ b/plugins/issue-to-pr/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "issue-to-pr",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "Take a GitHub issue (bare, or tracked on a Project board) from triage to a merge-ready PR through a gated, worktree-isolated pipeline that scales its depth to the task and asks at most one batched question. The gates hold every run: design hardening, tests green, code review clean. Once you approve the PR in-session it squash-merges; cleanup and the issue's auto-close follow only when the change landed in the default branch, and on any other base the run keeps the branch and says why. The board card advances as work moves.",
   "author": {
     "name": "Dmitry Yuhanov"

--- a/plugins/issue-to-pr/CHANGELOG.md
+++ b/plugins/issue-to-pr/CHANGELOG.md
@@ -5,16 +5,24 @@ All notable changes to the **issue-to-pr** plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [6.1.0] - 2026-09-02
+
+### Changed
+- Cut the instructions an agent reads before it can start from 382 lines to 361, dropping justification that had outgrown the rules it explained
+
+### Removed
+- Remove the friction log, which nothing has read since the `tune` skill went away
+
 ## [6.0.0] - 2026-08-31
 
 ### Added
 - Drive the built change at its own surface after the diff settles, so a PR has to do what it says and not only keep the tests green
 
 ### Changed
-- `--drill` becomes `--grill`: the checkpoint now interviews you over the design in rounds instead of teaching you a design already made, and it replaces the one batched question rather than adding a fourth interruption
+- Replace `--drill` with `--grill`, which interviews you over the design in rounds instead of teaching you one already made, and spends the checkpoint rather than adding a fourth interruption
 
 ### Removed
-- The `drill-me` marketplace from the setup skill's install table
+- Remove the `drill-me` marketplace from the setup skill's install table
 
 ## [5.3.0] - 2026-08-30
 

--- a/plugins/issue-to-pr/README.md
+++ b/plugins/issue-to-pr/README.md
@@ -27,29 +27,24 @@ progress; everything between them scales to the task.
 - **Scaled by tier.** Trivial, standard or complex (`--tier` overrides). Research depth,
   design machinery (an autonomous design panel for complex work), review level and passes,
   and report length all size to it.
-- **Autonomous, one question max.** The skill contacts you at three moments: one
-  batched question mid-run (only if something genuinely needs your preference), the merge
-  gate, and hard stops. Pass `--grill` and the first of those changes shape rather than
-  multiplying: instead of one batched question you get `grilling`, which works the design in
-  rounds of numbered decisions, each with a recommended answer, until nothing is left silently
-  assumed. It makes every other decision itself, logs it, and surfaces it in the report and PR
-  body.
+- **Autonomous, one checkpoint max.** Three moments: one batched question mid-run (only if
+  something needs your preference), the merge gate, and hard stops. `--grill` spends that first
+  moment on `grilling` instead, which works the design in rounds of numbered decisions until
+  nothing is left silently assumed. Every other decision it makes itself, logs, and surfaces in
+  the report and PR body.
 - **Gates.** Design hardening (cross-review or a multi-agent fallback), tests green
   (typecheck + tests, plus visual checks for UI work), and a code-review loop that runs
   until clean; the review level escalates automatically when passes keep finding real bugs.
-  Once the diff has settled, a last pass builds the change and drives it at its own surface,
-  because green tests are not the same claim as "the thing in the PR title happens".
+  Once the diff settles, a last pass builds the change and drives it at its own surface.
 - **Beyond a single issue.** A plain request with no number is drafted into an issue and run.
-- **A careful merge gate.** Merge happens only on your explicit in-session approval, never
-  on the turn the PR opens. What a script can prove, a script proves: the merge refuses a head
-  the gates never ran against, reads the GitHub review itself and stops on a requested change or
-  an unread one, and merges with `--match-head-commit`, so a commit landing after the diff you
-  were shown stops the merge instead of shipping unseen.
+- **A careful merge gate.** Merge happens only on your explicit in-session approval, never on
+  the turn the PR opens. The merge script refuses a head the gates never ran against, reads the
+  GitHub review itself, and passes `--match-head-commit`, so a commit landing after the diff you
+  were shown stops the merge rather than shipping unseen.
 - **Cleanup and a safety net.** After a merge into the default branch it deletes the branch,
-  tears down the worktree, and clears the run temp files; on any other base, or when the
-  landing branch cannot be confirmed, it keeps them and says so. An optional smoke
-  check runs on the updated base; if it fails, the skill opens a *draft* revert PR, never
-  an automatic rollback.
+  tears down the worktree, and clears the run's temp files; on any other base, or one it cannot
+  confirm, it keeps them and says so. An optional smoke check runs on the updated base; if it
+  fails, the skill opens a *draft* revert PR, never an automatic rollback.
 - **Board sync, gracefully.** Cards advance to *in-progress* at branch cut and *in-review*
   at PR open; `Done` is left to GitHub's merge-time automation. A missing `project` token
   scope degrades to link-only and never blocks the PR.
@@ -70,17 +65,13 @@ typecheck/test/visual/smoke commands. Everything is optional; with no file the r
 commands out in the worktree where the gates execute, as literals, and prints the block to
 paste here once they pass. It never writes this file itself.
 
-That directory holds the plugin's repository-level state - the config, gate receipts, the
-friction log - and it ships its own `.gitignore` containing `*`, so none of it reaches
-`git status` and your project's `.gitignore` is left alone. A run's own files - the design
-and its gate logs - live there too, under `runs/task-<N>/`, so nothing a run writes lands in
-your project tree where test discovery or a bundler would pick it up. A config at the
-older `.claude/issue-to-pr.local.md` path is not read; the run says so once and leaves it for
-you to move.
+That directory holds the plugin's state - the config, gate receipts, and each run's files under
+`runs/task-<N>/`. It ships its own `.gitignore` containing `*`, so none of it reaches
+`git status` and your project's `.gitignore` is left alone. A config at the older
+`.claude/issue-to-pr.local.md` path is not read; the run says so once and leaves it for you.
 
-Because the directory is ignored, `git clean -x` treats it as disposable and removes it along
-with the config and the gate receipt. Nothing breaks permanently: the commands get worked out
-again, but the next merge asks for one more gate run before it will land.
+Being ignored, the directory is disposable to `git clean -x`. Nothing breaks permanently: the
+commands get worked out again, and the next merge asks for one more gate run before it lands.
 
 ### Companion skills (optional)
 
@@ -89,10 +80,9 @@ diff at Step 7, its `simplify` is one of the two lenses of the Step 8 gate, and 
 closes that step by driving the built change. The CLI registers all three, so no marketplace
 is involved.
 
-`/deep-research` is built in too, but it is yours rather than the pipeline's: Claude Code
-only starts it when you type it. Step 2 always uses an `Explore` subagent, which is the
-ordinary path and not a lesser one. Want the deeper sweep? Run `/deep-research` in your own
-turn and hand the summary in.
+`/deep-research` is built in too, but it is yours rather than the pipeline's: Claude Code only
+starts it when you type it. Step 2 always uses an `Explore` subagent. For the deeper sweep, run
+`/deep-research` in your own turn and hand the summary in.
 
 Optional companions that sharpen specific steps: `superpowers:*`,
 `/cross-review` (from `codex-collaboration`), `humanizer`, `mattpocock-skills` (whose

--- a/plugins/issue-to-pr/skills/run/SKILL.md
+++ b/plugins/issue-to-pr/skills/run/SKILL.md
@@ -54,7 +54,7 @@ One todo per step.
 restates the request and nothing more, `gh issue create`, and make `Drafted issue #<N>: <title>`
 the **first output line of the turn** — that echo is the only guard against issue spam; ambiguous
 scope → ONE `AskUserQuestion` BEFORE creating it (the run's single question, moved
-earlier). Then work out the ground the run stands on, **in the main checkout**, never a worktree,
+earlier; `--grill` keeps it for the grill). Then work out the ground the run stands on, **in the main checkout**, never a worktree,
 following `R/configuration.md`: `gh auth status` (no auth → stop), `gh repo view`, the config file,
 `<BASE>` and `<START_POINT>`, the gate commands the config names, `gh issue view`, and claim the
 issue. **Report every warning that page tells you to raise** — an unresolved base surfaces there
@@ -103,20 +103,18 @@ shell variable in the same call and pass `--gate "test=$t"`, so the value reache
 one argument. Never judge a gate from an ad-hoc command: only this one surfaces the real failure.
 An empty gate command degrades (exit 4), never a false green. Red ⇒ STOP and fix.
 
-**7. Review loop.** Claude Code's built-in `code-review` skill at the tier's level, ≤ tier's max
-passes, and **without `--fix`** — that flag applies findings in one sweep, past the per-fix re-gate
-and the bug count the ratchet reads. Add adversarial subagents when the diff earns a second
-opinion (`R/companions.md`). Run reviewers in the **foreground**, never while gates run — one
-editing the shared worktree mid-gate produces a phantom red.
+**7. Review loop.** Built-in `code-review` at the tier's level, ≤ tier's max passes, **without
+`--fix`**: that flag sweeps findings in past the per-fix re-gate and the count the ratchet reads.
+Add adversarial subagents when the diff earns a second opinion (`R/companions.md`). Run reviewers
+in the **foreground**, never while gates run — one editing the tree mid-gate is a phantom red.
 **Security overlay:** list the surface with `<CHANGED>` = `{ git diff --name-only
 "<BASE>...HEAD"; git diff --name-only HEAD; git ls-files --others --exclude-standard; } | sort -u`
 — committed, uncommitted and untracked. Run `git rev-parse --verify "<BASE>^{commit}"` FIRST,
 every time: an unresolved base still prints a plausible list, minus every committed file. Decide
-from the diff whether it reaches auth, crypto, secrets, sessions, payments or migrations, add one
-`/security-review` if it does — judging the code, not the filename. A floor you may escalate from
-and never argue down: anything under `auth`, `crypto`, `secrets` or `migrations`, plus `.env*`,
-`*.sql`, `*.pem`, `*.key`.
-**Escalate a level** on 2+ confirmed bugs in a pass or a gate failing twice; re-run gates after each fix.
+from the diff, not the filename, whether it reaches auth, crypto, secrets, sessions, payments or
+migrations, and add one `/security-review` if it does. A floor you may escalate from and never
+argue down: `auth`, `crypto`, `secrets`, `migrations`, `.env*`, `*.sql`, `*.pem`, `*.key`.
+**Escalate a level** on 2+ confirmed bugs in a pass or a Step 6 gate failing twice; re-run gates after each fix.
 
 **8. Re-gates, simplification, verify.** Re-run `run-gates.sh` (all green). For any gate command
 you worked out yourself, **print** (never write) the `<CONFIG_PATH>` frontmatter block in the
@@ -170,9 +168,3 @@ an open PR. Report from its keys — `DELETED_LOCAL=false` or a `LEFTOVER_DIR` m
 remains; say so, remove it by hand once the lock clears. In-place fallback (no worktree): switch
 off `<branch>`, delete it local+remote, sweep the run's temp. Details: `R/contracts.md` →
 "worktree.sh". Finish with one line: what merged, what was removed, what was kept.
-
-## Friction log
-
-When a step genuinely fought back, append one dated one-line note to
-`.claude/issue-to-pr/friction.log`. Mention it in the report only once it is over 10 lines;
-it is the maintainer's list, not the run's.

--- a/plugins/issue-to-pr/skills/run/references/autonomy.md
+++ b/plugins/issue-to-pr/skills/run/references/autonomy.md
@@ -5,27 +5,17 @@ surfaces the automatic ones where the human already looks: the report and the PR
 
 ## Ask contract — three moments
 
-Contact the user at these three points. Nothing in the run may interrupt them anywhere else; a
-flag they passed themselves can.
+Contact the user at these three points and nowhere else.
 
-1. **Step 4 checkpoint** — ONE batched `AskUserQuestion`, only if the ledger has open
-   `asked` items. This is the single mid-run question, and it may move **earlier**, to Step 0,
-   when the ambiguity is in the request rather than in the design: the same one question, spent
-   sooner.
-
-   `--grill` spends the slot differently rather than adding to it: `mattpocock-skills:grilling`
-   works the design tree in rounds, each a numbered set of decisions with a recommended answer,
-   until the frontier is empty and the user confirms. It **replaces** the batched question, so
-   every open `asked` item goes **into** the grill, in its first round: the grill works the
-   design tree, the ledger holds what is not on it — a new dependency, a gate command Step 6
-   could not settle — and an item the grill never reaches is an item nobody asks. Ledger each
-   decision **as its round closes**, never in a batch at the end: a grill runs long enough for
-   the context to compact, and a decision that lived only in its transcript is gone when it
-   does. Anything surfacing after it belongs to moment (3), like any other late arrival.
-
-   Under the flag the grill **always** runs, including on a run whose scope question already
-   went at Step 0: Step 0 cannot defer that one, since an issue it drafts on a guessed scope is
-   the wrong issue. The flag is the user electing the longer form, and nothing here cancels it.
+1. **Step 4 checkpoint** — ONE batched `AskUserQuestion`, only if the ledger has open `asked`
+   items. It may move **earlier**, to Step 0, when the ambiguity is in the request rather than
+   the design. `--grill` spends the same slot instead: `mattpocock-skills:grilling` works the
+   design tree in rounds until the frontier is empty and the user confirms, and it **replaces**
+   the question, so every open `asked` item goes into its first round — including the Step 0
+   scope question, and including items the grill would never reach on its own, like a new
+   dependency or a gate command Step 6 could not settle. Ledger each decision **as its round
+   closes**: a grill runs long enough to compact, and a decision left only in its transcript is
+   gone when it does. Anything surfacing after it belongs to moment (3).
 2. **The merge gate** (Step 10) — always.
 3. **A hard stop** — anything with no safe default: an exit-2 (`WARN_CLAIMED_BY`, a
    gate-critical unknown), or a preference-bound choice that surfaced too late for
@@ -51,39 +41,29 @@ the PR body — the human reviews them at the merge gate they already attend.
 ## Two things that always earn an entry
 
 Both are `kind: auto`, and only `auto` entries render, so the wrong `kind` means the entry never
-reaches the PR body at all. Neither replaces an `asked` item: where the contract above reserves a
-choice for the human — a new **external** dependency or license is the usual one — the entry
-records the evidence and the choice still goes to them, at Step 4 before the checkpoint and as a
-hard stop after it. Checking is what makes that question worth asking, never a way to skip it.
+reaches the PR body. Neither replaces an `asked` item: where the contract reserves a choice for
+the human, usually a new **external** dependency, the entry records the evidence and the choice
+still goes to them. Checking is never a way to skip the question.
 
-**A claim about the world outside this repo that you have not checked.** Before building on how
-something outside it behaves while unsure of it, look it up: a design, a test, a line of code, a
-command about to run, a sentence going into the docs. Any tier, and one lookup for one doubt:
-Step 2's survey of unknowns is a different thing and only `complex` runs it. The `question` is
-the claim, the `decision` is what you built on it, and the `rationale` carries what you found
-**and where** — a conclusion with no source reads exactly like the guess this rule exists to
-stop.
+**A claim about the world outside this repo that you have not checked.** Look it up before you
+build on it, at any tier, one lookup per doubt (Step 2's survey of unknowns is a different thing
+and only `complex` runs it). The `question` is the claim, the `decision` is what you built on it,
+the `rationale` is what you found **and where**: a conclusion with no source reads like the guess
+this rule exists to stop. It goes here and **never into a design file** — `design.md` exists only
+on `complex` and Step 11 prunes it, so a citation left there dies unread.
 
-It goes here and **never into a design file**. `<RUN_DIR>/design.md` exists only on `complex`, and
-Step 11 prunes it once the change lands on the default branch, so a citation left there is
-deleted before any reader sees it. The ledger is the one path that reaches the PR
-body from every tier.
+Use whatever search the session offers, except `/deep-research` (`R/companions.md`). No search at
+all excuses the lookup, never the entry: say in the `rationale` that the claim went unchecked and
+what you assumed instead.
 
-Use whatever search the session offers, except `/deep-research` (`R/companions.md`). Nothing else
-is named, deliberately, because ranking search tools belongs to the operator's own instructions.
-No search at all is an exemption from the lookup and never from the entry: say in the `rationale`
-that the claim went unchecked, and what you assumed instead.
-
-**Work no reviewer saw.** The last review pass a tier allows changed something, or Step 8 applied
-a cut after the loop had closed: either way it reaches the merge gate unread. This is **not**
-gated on the ratchet, which needs two confirmed bugs; one bug on the final pass leaves its fix
-exactly as unread. The `question` is what went unreviewed, the `decision` is that you stopped
-rather than overrunning the cap, the `rationale` names the files so the reader knows where to
-look hardest. Say it whatever the tier: a `trivial` report is three lines and this is worth one
-of them. File it when it applies and not otherwise, since a caveat attached to every run is one
-nobody reads.
+**Work no reviewer saw.** The last review pass a tier allows changed something, or Step 8 cut
+after the loop closed: either way it reaches the merge gate unread. Not gated on the ratchet,
+which needs two confirmed bugs; one bug on the final pass leaves its fix exactly as unread. The
+`question` is what went unreviewed, the `decision` is that you stopped rather than overrunning
+the cap, the `rationale` names the files so the reader knows where to look hardest. File it
+whenever it applies and never otherwise, since a caveat on every run is one nobody reads.
 
 ## Resume after an interruption
 
-`git status`, `gh pr view` and the gate logs under `<RUN_DIR>/logs` answer where the run
-stopped. Trust them over recollection — they are what the outside world actually shows.
+`git status`, `gh pr view` and the gate logs under `<RUN_DIR>/logs` answer where the run stopped.
+Trust them over recollection.

--- a/plugins/issue-to-pr/skills/run/references/companions.md
+++ b/plugins/issue-to-pr/skills/run/references/companions.md
@@ -16,42 +16,20 @@ companion silently degrade quality without saying so.
 | Diff review loop (Step 7) | `code-review` at the tier's level | Independent adversarial review subagents (2–3) critique the diff for correctness, reuse, and regressions; iterate. |
 
 `code-review`, `simplify` and `verify` are **built into Claude Code** — invoke them by bare
-name, no install, no namespace, no `if installed` branch. They carry their own fallbacks when
-the Agent tool is unavailable, and `code-review` sizes its own finder fan-out to the diff.
-`verify` has no row above because it has no fallback worth the name: driving a built artifact
-at its real surface is not something you approximate by reading the diff again. Which tiers get
-the slot is `R/tier-matrix.md`; the rules that govern it are at the bottom of this file.
+name, no install, no namespace, no `if installed` branch. `code-review` sizes its own finder
+fan-out to the diff.
+`verify` has no row because it has no fallback: you cannot approximate driving a built artifact
+by reading the diff again.
 
-`deep-research` is built in as well, but it is **not the run's to use**: since 2.1.218 Claude
-Code starts it only when the user types `/deep-research` themselves. There is no branch here
-and no row above, because there is no choice to make. Step 2's `Explore` subagent is simply
-what Step 2 does; a user wanting the deeper sweep runs the command in their own turn.
+`deep-research` is built in as well but is **not the run's to use**: since 2.1.218 Claude Code
+starts it only when the user types it. No branch, no row — Step 2 uses its `Explore` subagent,
+and a user wanting the deeper sweep runs the command in their own turn.
 
-Step 7 declines `code-review --fix`: a sweep of applied fixes lands past the per-fix re-gate
-and past the confirmed-bug count the escalation ratchet reads. Fix findings yourself, one at
-a time, re-running the gates between them.
+Ponytail's `SubagentStart` hook carries the mode into every subagent, so setting it once at
+Step 3 is the whole wiring. Step 7's reviewers inherit it: it governs how a confirmed bug gets
+fixed, never whether it counts as one.
 
-Ponytail's own `SubagentStart` hook carries the mode into every subagent, so setting it once
-at Step 3 is the whole wiring — pass nothing along. Step 7's reviewers inherit it too; their
-prompt says it governs how a confirmed bug gets fixed, never whether it counts as one.
-
-## The Step 8 verify slot
-
-Green gates prove the tests pass. They do not prove the thing the PR claims to do actually
-happens. That gap is what the slot closes, and it is why the three rules are what they are.
-
-**Last in the step, after simplification.** That gate is still applying cuts and re-gating, so
-anything verified ahead of it was verified against a diff that then moved.
-
-**A diff with nothing runnable skips the slot, rather than recording a skip.** Research, docs and
-prose outcomes have no surface to drive, and a verdict collected on every run, most of them
-empty, is one nobody reads by the tenth PR. This pipeline's own runs skip more often than not:
-its surface is a Claude session reading prose, which no terminal can drive.
-
-**A FAIL never counts toward the ratchet.** The ratchet raises the review level, a level only
-buys another review pass, and by Step 8 the loop has closed: the escalation would have nothing
-to spend. A FAIL is stop-and-fix and re-gate, and the fix lands after the last review pass,
-where "Work no reviewer saw" in `R/autonomy.md` already covers it.
-
-These are recommendations, not requirements — the skill checks availability at the relevant
-step and proceeds either way.
+Step 8 runs `verify` **last**, after the simplification gate has stopped moving the diff. A
+FAIL is stop-and-fix and re-gate, never a ratchet count: the ratchet raises the review level, a
+level buys another review pass, and by Step 8 the loop has closed. The fix then lands after the
+last review pass, so "Work no reviewer saw" in `R/autonomy.md` covers it.

--- a/plugins/issue-to-pr/skills/run/references/configuration.md
+++ b/plugins/issue-to-pr/skills/run/references/configuration.md
@@ -1,18 +1,16 @@
 # Step 0 — the config, the base, and claiming the issue
 
-Everything here resolves against the **main checkout**, never a worktree. The config is
-usually untracked, so a worktree has no copy of it, and on a resume you are standing in one.
+Everything here resolves against the **main checkout**, never a worktree, which has no copy of
+an untracked config.
 
 ## The config file — `.claude/issue-to-pr/config.md`
 
-Optional per-project settings: YAML frontmatter, optional markdown notes below. That
-directory holds the plugin's repository-level state and carries its own `.gitignore` whose
-**first** rule is `*`, so a teammate without the plugin never sees a file they cannot place
-and the project's own `.gitignore` is never edited. Create it that way before writing
-anything into it — the friction log and the gate receipt both land there. A run's own files
-live beside it under `runs/task-<N>/` and go at cleanup: that path, in the main checkout and
-never in a worktree, is the `<RUN_DIR>` the spine writes designs and gate logs to. A config left at the pre-2.5 path
-(`.claude/issue-to-pr.local.md`) is not read: say so once and leave the file alone.
+Optional per-project settings: YAML frontmatter, markdown notes below. Create the directory
+with its own `.gitignore` whose **first** rule is `*` before writing anything into it, so a
+teammate without the plugin never sees a file they cannot place and the project's own
+`.gitignore` is left alone. The gate receipt lands there, and a run's files
+under `runs/task-<N>/` — that path is `<RUN_DIR>`, and cleanup takes it. A config at the pre-2.5
+path (`.claude/issue-to-pr.local.md`) is not read: say so once and leave it alone.
 
 ```yaml
 ---
@@ -60,10 +58,9 @@ the base and the default branch (the one the in-place fallback switches onto):
 git fetch origin --no-prune --quiet "+refs/heads/<BASE>:refs/remotes/origin/<BASE>"
 ```
 
-`--no-prune` is not optional: a user with `fetch.prune` set would otherwise have their
-remote-tracking refs deleted as a side effect of a probe that runs on every task. And fetch
-**one refspec per invocation** — `git fetch` fails the whole call if any single refspec names
-a ref the remote lacks, so an absent default branch would take the base down with it.
+`--no-prune` is not optional: with `fetch.prune` set, a probe that runs on every task would
+delete the user's remote-tracking refs. Fetch **one refspec per invocation**: `git fetch` fails
+the whole call if any refspec names a ref the remote lacks.
 
 `START_POINT` is `origin/<BASE>` when that ref verifies. Otherwise fall back and say so:
 a local `<BASE>` means you are cutting from a branch nothing verified; no ref at all means
@@ -78,8 +75,8 @@ Never run a design on an issue somebody else has taken.
 
 ## Warnings
 
-Every "say so" above is part of Step 0's answer, including on the runs that then stop for
-another reason. Report them; a warning nobody prints is a warning that was never raised.
+Every "say so" above is part of Step 0's answer, including on runs that then stop for another
+reason. A warning nobody prints was never raised.
 
 ## The board
 

--- a/plugins/issue-to-pr/skills/run/references/contracts.md
+++ b/plugins/issue-to-pr/skills/run/references/contracts.md
@@ -3,26 +3,22 @@
 The pipeline's git/gh mechanics live in tested bash scripts under
 `${CLAUDE_PLUGIN_ROOT}/scripts/` (this plugin), not in prose. Each script owns the *mechanics*;
 the model owns *judgment*. Every human-judgment stop is an exit code, never a silent script
-decision. This file is the reference: what to call, when, and how to read the result.
+decision.
 
 ## How the scripts talk back
 
-- **Output:** each script prints `KEY=VALUE` lines on stdout (the machine block). Lists are
-  comma-joined strings. Human hints go to stderr. A green run is a handful of lines — that printed block IS your
-  verification-before-completion proof.
+- **Output:** each script prints `KEY=VALUE` lines on stdout, lists comma-joined; hints go to
+  stderr. That printed block is your proof a step passed — never claim one without it.
 - **Uniform exit codes:** `0` proceed · `2` stop-and-ask (reason in `STOP_REASON=`, a hint on
   stderr) · `3` sandbox/permission fallback (do it in place) · `4` degraded (could not parse/reach
   something — do that part by hand). Exceptions noted per script below.
-- Read the config **once in the main checkout** at Step 0 (`R/configuration.md`, which says where
-  it lives and why a worktree has no copy) and carry the resolved values; never re-read it from
-  inside the worktree.
+- Read the config **once in the main checkout** at Step 0 (`R/configuration.md`) and carry the
+  resolved values; never re-read it from inside the worktree.
 
 On a stop, `worktree.sh` emits the raw failure alongside `STOP_REASON`: `ADD_ERROR`,
-`DIRTY_FILES`, `PUSH_ERROR`, `MERGE_ERROR`. Read whichever is present and report it
-verbatim - it is the only place the underlying git/gh message survives.
-
-A stop is never a fix: on exit 2 the script hands control back, and you report the exact
-error rather than working around it.
+`DIRTY_FILES`, `PUSH_ERROR`, `MERGE_ERROR`. Report whichever is present verbatim; it is the only
+place the underlying git/gh message survives. A stop is never a fix: report the error rather
+than working around it.
 
 ## worktree.sh — worktree + merge mechanics (SAFETY-CRITICAL)
 

--- a/plugins/issue-to-pr/skills/run/references/tier-matrix.md
+++ b/plugins/issue-to-pr/skills/run/references/tier-matrix.md
@@ -11,9 +11,8 @@ moved it. Borderline picks the **higher** tier.
 | `code-review` level | `low`, 1 pass | `medium`, <=2 passes | `high`, <=3 passes (may raise to `max` on escalation) |
 | Step 8 `verify` | - | when the diff left something runnable | as standard |
 
-Gates, the security overlay, and the external-claim check run at every tier, always. That last
-one scales to nothing at all, so it lives in `R/autonomy.md` with the other ledger rules rather
-than in a table whose three columns would say the same thing.
+Gates, the security overlay, and the external-claim check run at every tier, always; the last
+of those lives in `R/autonomy.md` with the other ledger rules.
 
 ## Signals, strongest first
 
@@ -34,7 +33,6 @@ along with the tier and gives it both a design step and the Step 8 verify slot t
 raising a level inside a tier buys no extra pass. Report the raw per-pass counts at Step 9 so a
 missed ratchet is visible at the merge gate.
 
-The cap is the cap. Another pass is how a review loop stops terminating, and the human at the
-merge gate is the backstop this pipeline is built on. So stop, and ledger what stopping cost —
-the entry's shape, and the fact that it is owed whether or not the ratchet ever fired, are in
-`R/autonomy.md` under "Work no reviewer saw".
+The cap is the cap: another pass is how a review loop stops terminating, and the human at the
+merge gate is the backstop. Stop, and ledger what stopping cost — `R/autonomy.md`, "Work no
+reviewer saw", owed whether or not the ratchet ever fired.

--- a/plugins/issue-to-pr/tests/contract/test_skill-lint.sh
+++ b/plugins/issue-to-pr/tests/contract/test_skill-lint.sh
@@ -86,14 +86,9 @@ test_skill_smoke_gate_passes_a_log_dir_before_cleanup() {
   assert_contains "$c" 'run-gates.sh --log-dir "<RUN_DIR>/logs"'
 }
 
-# `--grill` is the one way a run spends the human's time on purpose instead of saving it. It
-# REPLACES the batched question rather than joining it: grilling works the design tree in
-# rounds until the frontier is empty and stops on the user's confirmation, which is the
-# checkpoint's own job done properly. So the number in the ask contract stays three.
-#
-# Its predecessor `--drill` did add a fourth moment, and that is the shape an edit restores by
-# reflex, so the old flag and the old count are both checked for below. A flag nobody can
-# discover is a flag nobody passes: the frontmatter advertises it.
+# `--grill` REPLACES the batched question rather than joining it, so the ask contract stays at
+# three moments. Its predecessor `--drill` added a fourth, and that is the shape an edit
+# restores by reflex, so the old flag and the old count are both checked for by name.
 test_skill_grill_reshapes_the_checkpoint_without_adding_a_moment() {
   local s blk ask f live
   s=$(cat "$(skill_md)")
@@ -101,9 +96,8 @@ test_skill_grill_reshapes_the_checkpoint_without_adding_a_moment() {
   grep -q 'argument-hint:.*--grill' "$(skill_md)" ||
     fail "argument-hint must advertise --grill"
 
-  # Every file that carried a drill row, not just the spine - that is where the rot would sit,
-  # and the companion walk below asks for `grilling` without forbidding what it replaced.
-  # CHANGELOG.md is deliberately exempt: it is version-scoped and its history is meant to age.
+  # Every file that carried a drill row, not just the spine. CHANGELOG.md is exempt: it is
+  # version-scoped and its history is meant to age.
   for f in "$(skill_md)" "$(setup_md)" "$ITP_SCRIPTS"/../skills/run/references/*.md \
            "$ITP_SCRIPTS/../README.md" "$ITP_SCRIPTS/../../../README.md"; do
     live=$(cat "$f")
@@ -115,13 +109,11 @@ test_skill_grill_reshapes_the_checkpoint_without_adding_a_moment() {
   [ -n "$blk" ] || fail "Step 4 came back empty; this check would be vacuous"
   assert_contains "$blk" 'grilling' "the checkpoint must run the grill when --grill asked for it"
   assert_contains "$blk" 'AskUserQuestion' "the checkpoint lost its batched question"
-  # That pair is not enough on its own: a Step 4 that grills and THEN fires the question
-  # satisfies both while spending two contacts, which is the fourth moment under a new name.
+  # Those two alone pass on a Step 4 that grills and THEN asks, which is two contacts.
   assert_contains "$blk" 'replaces' \
     "Step 4 must say the grill REPLACES the batched question, not merely that both exist"
 
-  # -A3, not a bare grep: the bullet wraps over three lines, and a budget that keeps forcing
-  # reflows would move `four` off the matched line without the rule changing at all.
+  # -A3: the bullet wraps, and a reflow would move `four` off a line-scoped match.
   ask=$(printf '%s\n' "$s" | grep -A3 -i 'ask contract:')
   [ -n "$ask" ] || fail "the spine no longer states the ask contract"
   case "$ask" in
@@ -147,26 +139,19 @@ test_setup_walks_every_companion_the_run_knows() {
   done
 }
 
-# Twice now a built-in has been advertised as something to install: `code-review` in
-# companions.md, then `deep-research` in three places at once. Every one slipped past the
-# companion-walk test above, which only checks that the NAME appears somewhere. Hence three
-# regions, each a place whose whole meaning is "you have to install this", and all three
-# checked: the first cut of this test read the setup table alone and went green while both
-# READMEs were still wrong.
+# Twice now a built-in has been advertised as something to install: `code-review`, then
+# `deep-research` in three places at once. Both slipped past the companion walk above, which
+# only asks whether the NAME appears somewhere. Hence three regions, each one a place whose
+# whole meaning is "you have to install this" - the first cut of this test read the setup
+# table alone and went green while both READMEs were still wrong.
 #
-# companions.md gets a narrower rule of its own, at the bottom. The blanket one cannot apply
-# there: its Preferred column legitimately holds `code-review` and `simplify` in their own
-# rows, so banning all three would fail on correct prose. `deep-research` is different, and
-# per-name, because it has no preferred-versus-fallback shape to occupy a row with. The
-# `code-review` incident that opens this comment stays unguarded.
+# Regions 2 and 3 are prose, so the rule is blunt: any mention trips it, a correct one
+# included. A false red costs a minute; a false green shipped this bug twice. Reword the
+# prose or narrow the slice, never delete the check. That bluntness is why companions.md is
+# not a region: its Preferred column legitimately names `code-review` and `simplify`.
 #
-# Regions 2 and 3 are prose, so the rule there is blunt: any mention trips it, a correct one
-# included. Deliberate. A false red costs a minute; a false green shipped this bug twice.
-# Reword the prose or narrow the slice, never delete the check.
-#
-# `verify` joined the set with the Step 8 slot. It is the riskiest name of the four, because
-# unlike the others it is an ordinary English word: keep it out of these three regions by
-# rewording them, never by dropping it from the list.
+# `verify` is the riskiest name here, being an ordinary English word. Keep it out of the
+# three regions by rewording them, never by dropping it from the list.
 no_builtins() { # region label
   local c
   [ -n "$1" ] || fail "$2 came back empty; this check would be vacuous"


### PR DESCRIPTION
The deletion pass belonged in #66 and never reached the commit. This is it, landing on its own.

## How it got lost

The pre-commit hook compares the staged `plugin.json` against `git show HEAD:plugin.json`, so a second commit on a branch is rejected and every amend goes through `git reset --soft HEAD~1` and a recommit. That reset puts the *previous* commit's tree back in the index. I then staged only the files edited since, so the cuts to nine other files stayed in the working tree and out of the commit.

What hid it was the measurement. `git diff main --shortstat` compares the **working tree** to main, not the commit, so it reported the cuts as present and I read that as the PR's diff. Every figure I gave for #66 described files on disk that were never committed. `git diff main...HEAD` is the form that answers the question being asked, and this branch was verified with it plus a clean `git status`.

#66 itself is fine and its content is correct; it is simply smaller than advertised. The `board.md` and `common.sh` fixes from the last round did ship, because those were the two files staged.

## What lands here

`git diff main...HEAD`: **11 files, +138, −214.**

| read before a run can start | 5.3.0 | 6.0.0 | here |
|---|---|---|---|
| `SKILL.md` | 179 | 179 | **170** |
| `configuration.md` | 86 | 86 | 84 |
| `autonomy.md` | 78 | 78 | **69** |
| `tier-matrix.md` | 39 | 39 | 38 |
| **total** | **382** | **382** | **361** |

`README.md` drops 111 to 106, `companions.md` and `board.md` a line each. v5.3.0 took this number from 418 to 382; this takes another 21 off it.

Three shapes accounted for most of the cut:

- Sentences announcing what the next paragraph was about to say.
- A reference file narrating its own version history.
- Duplication: `companions.md` restating the `--fix` rule the spine already gives *with* its reason, then closing on a line that repeated the file's own opening.

## The friction log

Nothing has read `.claude/issue-to-pr/friction.log` since `tune` was removed in v4, so every run since has appended to a file with no consumer. Exporting a session covers the same need on the rare occasion it comes up.

The 6.0.0 changelog entry announcing this removal did not ship either, so nothing on `main` was claiming a removal it had not made. That bullet moves to 6.1.0, where the removal actually happens.

What stays is the older changelog history: three entries in past releases that mention the log. They are the record that it existed, and editing shipped release notes would make them false.

## The check that caught a real loss

After cutting this hard, every skill file was diffed against `main` at word level and every phrase of six or more words that had disappeared was listed and judged one by one. Almost all of it was justification.

**One was a rule.** The shape of the unreviewed-work ledger entry (`question` is what went unreviewed, `decision` is that you stopped rather than overrun the cap) had vanished from `autonomy.md` *and* from the `tier-matrix.md` line that pointed at it, in the same pass. Both copies at once, which is exactly how a rule disappears without anyone noticing. Restored.

That check is the one worth repeating after any aggressive deletion: a line count tells you the file got shorter, not whether it still says everything it has to.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the issue-to-PR plugin to version 6.1.0.
  * Refined the `--grill` workflow and clarified its interaction points and review process.
  * Improved run-state cleanup and configuration guidance.

* **Documentation**
  * Updated the README, changelog, workflow references, and configuration guidance.
  * Removed obsolete friction-log instructions and clarified built-in tool usage.

* **Tests**
  * Improved test comments describing grill behavior and built-in tool validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->